### PR TITLE
New config structure, load & save

### DIFF
--- a/docs/software/firmware/obs_cfg.md
+++ b/docs/software/firmware/obs_cfg.md
@@ -1,0 +1,86 @@
+# OpenBikeSensor configuration
+
+This file describes the configuration format of the OBS internal(!)
+configuration file. Please note that even that the format seems well
+documented, it is considered an internal format which might change at
+any time. There might be interpretations possible in which case 
+the current implementation defines the correct used. 
+
+The configuration is prepared for extension to support configuration 
+presets, where certain values of the "default" configuration can be
+changed for a certain presets. The handle bar offsets are very likely
+candidates for this. The Wi-Fi or Portal configuration is more likely 
+not part of a presets.
+
+When working with backups please note that the configuration file contains 
+your Wi-Fi password, and the portal token in plain text. 
+Both values are secrets that should not be disclosed, so keep the backup
+at a save place and replace these values when sharing.
+
+## cfg.obs
+
+Use the annotated sample file as documentation, order of the keys is not
+relevant put the order of the array content.
+
+```json5
+{
+  // obs must be an array. It can contain possibly multiple entries, 
+  // the 1st defines default values for all presets, and the default presets.
+    "obs": [ 
+        {
+          // enables / disables bluetooth
+            "bluetooth": true,
+          // time window for overtake measurement confirmation
+            "confirmationTimeSeconds": 4,
+          // Bitfield for some internal developer features 
+            "devConfig": 0,
+          // Bitfield display config, see DisplayOptions for details, 
+          // as noted all subject to change!
+            "displayConfig": 15,
+          // For what GPS fix should the OBS wait at startup?
+          // -2: FIX POS; -1: Time only; 0: No wait
+            "gpsFix": -2,
+          // Textual name of the profile - waiting for fetures to come.
+            "name": "default",
+          // Name of the OBS, will be used for WiFo, Bluetooth and other places 
+          // currently no way to change it, consists of OpenBikeSensor-<deviceId>  
+            "obsName": "OpenBikeSensor-affe",
+          // The handle bar offset in cm, order right, left.  
+            "offset": [
+                31,
+                32
+            ],
+          // Token used to authenticate and authorize at the portal.
+            "portalToken": "thisIsAlsoSecret",
+          // URL of the portal to be used (currently it is hardcoded, the value is not used)
+            "portalUrl": "https://openbikesensor.hlrs.de",
+          // Array with privacy areas to be considered
+            "privacyArea": [
+                {
+                  // latitude of the entered value, for documentation and display purpose only
+                    "lat": 48.001,
+                  // shifted latitude used for position filtering
+                    "latT": 48.00105,
+                  // longitude of the entered value, for documentation and display purpose only
+                    "long": 9.001,
+                  // shifted longitude used for position filtering
+                    "longT": 9.001121,
+                  // radius in meters around the position to be filtered
+                    "radius": 101
+                }
+            ],
+          // Bitfield for the privacy configuration see PrivacyOptions
+            "privacyConfig": 10,
+          // Active preset - always 0 as of today
+            "selectedPreset": 0,
+          // Selects if the SimRa mode is activated
+            "simRa": false,
+          // Password of your Wi-Fi where the OBS should log into in server mode
+            "wifiPassword": "swordfish",
+          // SSID of your Wi-Fi where the OBS should log into in server mode
+            "wifiSsid": "obs-cloud"
+        }
+    ]
+}
+```
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,8 +29,8 @@ upload_speed = 921600
 board_build.partitions = min_spiffs.csv
 ; The following dependencies can either use their full name or their (platformio library) id
 lib_deps =
-    ; ArduinoJson by Benoit Blanchon
-    ArduinoJson
+    ; https://arduinojson.org/v6/api/
+    bblanchon/ArduinoJson @ ^6.17.2
     ; CircularBuffer by AgileWare
     1796
     ; TinyGPSPlus by Mikal Hart

--- a/src/OpenBikeSensorFirmware.cpp
+++ b/src/OpenBikeSensorFirmware.cpp
@@ -20,6 +20,8 @@
 
 #include "OpenBikeSensorFirmware.h"
 
+#include "SPIFFS.h"
+
 #ifndef BUILD_NUMBER
 #define BUILD_NUMBER "local"
 #endif
@@ -63,7 +65,6 @@ unsigned long timeOfMinimum = esp_timer_get_time(); //  millis();
 unsigned long startTimeMillis = 0;
 unsigned long currentTimeMillis = millis();
 
-bool usingSD = false;
 String text = "";
 uint16_t minDistanceToConfirm = MAX_SENSOR_VALUE;
 uint16_t minDistanceToConfirmIndex = 0;
@@ -123,23 +124,25 @@ void setup() {
     displayTest->showTextOnGrid(2, 1, "Config... error ");
     return;
   }
-  // Should load default config if run for the first time
+
   Serial.println(F("Load config"));
-  loadConfiguration(configFilename, config);
+  ObsConfig cfg; // this one is valid in setup!
+  if (!cfg.loadConfig()) {
+    displayTest->showTextOnGrid(2, 1, "Config...RESET");
+    delay(1000); // resetting config once, wait a moment
+  }
 
   // Dump config file
-  Serial.println(F("Print config file..."));
-  printConfig(config);
+  log_d("Print config file...");
+  cfg.printConfig();
 
-  // Save the config. This ensures, that new options exist as well
-  saveConfiguration(configFilename, config);
+  // TODO: Select Profile missing here or below!
+  // Copy data to static view on config!
+  cfg.fill(config);
 
-#ifdef DEVELOP
   if(config.devConfig & ShowGrid) {
     displayTest->showGrid(true);
   }
-#endif
-
   if (config.displayConfig & DisplayInvert) {
     displayTest->invert();
   } else {
@@ -201,7 +204,7 @@ void setup() {
 
     delay(1000); // Added for user experience
 
-    startServer();
+    startServer(&cfg);
     OtaInit(esp_chipid);
 
     while (true) {
@@ -263,45 +266,50 @@ void setup() {
   voltageMeter = new VoltageMeter; // takes a moment, so do it here
 
   delay(300);
+  int gpsWaitFor = cfg.getProperty<int>(ObsConfig::PROPERTY_GPS_FIX);
   while (!validGPSData) {
     readGPSData();
 
-    switch (config.GPSConfig) {
-      case ValidLocation: {
-        validGPSData = gps.location.isValid();
+    switch (gpsWaitFor) {
+      case GPS::FIX_POS:
+        validGPSData = gps.sentencesWithFix() > 0;
         if (validGPSData) {
           Serial.println("Got location...");
         }
         break;
-      }
-      case ValidTime: {
-        validGPSData = gps.time.isValid();
+      case GPS::FIX_TIME:
+        validGPSData = gps.time.isValid()
+          && !(gps.time.second() == 00 && gps.time.minute() == 00 && gps.time.hour() == 00);
         if (validGPSData) {
           Serial.println("Got time...");
         }
         break;
-      }
-      case NumberSatellites: {
-        validGPSData = gps.satellites.value() >= config.satsForFix;
+      case GPS::FIX_NO_WAIT:
+        validGPSData = true;
+        if (validGPSData) {
+          Serial.println("GPS, no wait");
+        }
+        break;
+      default:
+        validGPSData = gps.satellites.value() >= gpsWaitFor;
         if (validGPSData) {
           Serial.println("Got required number of satellites...");
         }
         break;
-      }
-      default: {
-        validGPSData = false;
-      }
-
     }
-    delay(300);
+    delay(50);
 
     String satellitesString;
     if (gps.passedChecksum() == 0) { // could not get any valid char from GPS module
       satellitesString = "OFF?";
-    } else if (!gps.time.isValid()) {
+    } else if (!gps.time.isValid()
+        || (gps.time.second() == 00 && gps.time.minute() == 00 && gps.time.hour() == 00)) {
       satellitesString = "no time";
     } else {
-      satellitesString = String(gps.satellites.value()) + " / " + String(config.satsForFix) + " sats";
+      char timeStr[32];
+      snprintf(timeStr, sizeof(timeStr), "%02d:%02d:%02d %dsa",
+               gps.time.hour(), gps.time.minute(), gps.time.second(), gps.satellites.value());
+      satellitesString = String(timeStr);
     }
     displayTest->showTextOnGrid(2, 5, satellitesString);
 
@@ -313,12 +321,6 @@ void setup() {
       displayTest->showTextOnGrid(2, 5, "...skipped");
       break;
     }
-  }
-
-  if (gps.satellites.value() >= config.satsForFix) {
-    Serial.print("Got GPS Fix: ");
-    Serial.println(String(gps.satellites.value()));
-    displayTest->showTextOnGrid(2, 5, "Got GPS Fix");
   }
 
   //##############################################################
@@ -449,8 +451,8 @@ void loop() {
   } // end measureInterval while
 
   // Write the minimum values of the while-loop to a set
-  for (size_t idx = 0; idx < sensorManager->m_sensors.size(); ++idx) {
-    currentSet->sensorValues.push_back(sensorManager->m_sensors[idx].minDistance);
+  for (auto & m_sensor : sensorManager->m_sensors) {
+    currentSet->sensorValues.push_back(m_sensor.minDistance);
   }
   currentSet->measurements = sensorManager->lastReadingCount;
   memcpy(&(currentSet->readDurationsRightInMicroseconds),
@@ -487,7 +489,7 @@ void loop() {
     // Empty buffer by writing it, after confirmation it will be written to SD card directly so no confirmed sets will be lost
     while (!dataBuffer.isEmpty() && dataBuffer.first() != datasetToConfirm) {
       DataSet* dataset = dataBuffer.shift();
-      if (dataset->confirmedDistances.size() == 0) {
+      if (dataset->confirmedDistances.empty()) {
         if (writer) {
           writer->append(*dataset);
         }

--- a/src/configServer.h
+++ b/src/configServer.h
@@ -42,7 +42,7 @@
 //DNSServer dnsServer;
 
 extern WebServer server;
-void startServer();
+void startServer(ObsConfig *pConfig);
 void createPrivacyPage();
 
 #endif

--- a/src/displays.cpp
+++ b/src/displays.cpp
@@ -92,7 +92,7 @@ void SSD1306DisplayDevice::showValues(
       showNumConfirmed();
     } else {
       // Show GPS info, when DisplaySatellites is configured
-      if (config.displayConfig & DisplaySatelites) {
+      if (config.displayConfig & DisplaySatellites) {
         showGPS();
       }
 

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -126,9 +126,10 @@ void readGPSData() {
 bool isInsidePrivacyArea(TinyGPSLocation &location) {
   // quite accurate haversine formula
   // consider using simplified flat earth calculation to save time
-  for (size_t idx = 0; idx < config.numPrivacyAreas; ++idx) {
-    double distance = haversine(location.lat(), location.lng(), config.privacyAreas[idx].transformedLatitude, config.privacyAreas[idx].transformedLongitude);
-    if (distance < config.privacyAreas[idx].radius) {
+  for (auto pa : config.privacyAreas) {
+    double distance = haversine(
+      location.lat(), location.lng(), pa.transformedLatitude, pa.transformedLongitude);
+    if (distance < pa.radius) {
       return true;
     }
   }
@@ -198,17 +199,11 @@ void randomOffset(PrivacyArea &p) {
 #endif
 }
 
-void addNewPrivacyArea(double latitude, double longitude, int radius) {
+PrivacyArea newPrivacyArea(double latitude, double longitude, int radius) {
   PrivacyArea newPrivacyArea;
   newPrivacyArea.latitude = latitude;
   newPrivacyArea.longitude = longitude;
   newPrivacyArea.radius = radius;
   randomOffset(newPrivacyArea);
-
-  config.privacyAreas.push_back(newPrivacyArea);
-  config.numPrivacyAreas = config.privacyAreas.size();
-  Serial.println(F("Print config file..."));
-  printConfig(config);
-  Serial.println(F("Saving configuration..."));
-  saveConfiguration(configFilename, config);
+  return newPrivacyArea;
 }

--- a/src/gps.h
+++ b/src/gps.h
@@ -28,13 +28,19 @@
 #include "config.h"
 #include "globals.h"
 
+namespace GPS {
+  const int FIX_NO_WAIT = 0;
+  const int FIX_TIME = -1;
+  const int FIX_POS = -2;
+}
+
 extern TinyGPSPlus gps;
 extern HardwareSerial SerialGPS;
 
 time_t currentTime();
 void readGPSData();
 bool isInsidePrivacyArea(TinyGPSLocation &location);
-void addNewPrivacyArea(double latitude, double longitude, int radius);
+PrivacyArea newPrivacyArea(double latitude, double longitude, int radius);
 double haversine(double lat1, double lon1, double lat2, double lon2);
 
 #endif

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -84,12 +84,14 @@ bool FileWriter::appendString(const String &s) {
   if (!stored && getBufferLength() < 11000) { // do not add data if our buffer is full already. We loose data here!
     mBuffer.concat(s);
     stored = true;
-  } else {
-#ifdef DEVELOP
-    Serial.printf("File buffer overflow, not allowed to write - "
-                  "will skip, memory is at %dk.\n", ESP.getFreeHeap() / 1024);
-#endif
   }
+#ifdef DEVELOP
+  if (!stored) {
+    Serial.printf("File buffer overflow, not allowed to write - "
+                  "will skip, memory is at %dk, buffer at %u.\n",
+                  ESP.getFreeHeap() / 1024, getBufferLength());
+  }
+#endif
   return stored;
 }
 


### PR DESCRIPTION
- Create and document a new clean JSON for the configuration #118
- Config format is structured json this allows:
  - PrivacyAreas are stored as array inside Json (not a properties with counter in the property name)
  - SensorOffstes are stored as array inside Json
- Main config is inside a array which is prepared to hold different config profiles for certain values.
- Configuration file is not re-written at each OBS restart, only ServerMode writes config
- A backup of the configuration is created before writing the new config (might be dropped again SPIFFS if memory gets low)
- If the current config can not be read from SPIFFS the backup is loaded if possible
- Old config is accepted in backup/restore dialog
- Some values had been dropped / replaced
  - hostname / port, is not used now a PORTAL_URL is added (still not used)
  - obsUsreId is now called PORTAL_TOKEN which is more reflecting the use
  - gpsFix, now has 3 states: `FIX_POS`, `FIX_TIME` and `FIX_NO_WAIT` 
- Lot of changes are preparations only for further changes


Testers wanted: 
⚠️ Make a backup of your configuration before updating. The current release version loads the old config format only. 



