### PR TITLE
Remove options for various GPS waits, closes #251

### DIFF
--- a/docs/software/firmware/csv_format.md
+++ b/docs/software/firmware/csv_format.md
@@ -39,6 +39,7 @@ understand.
 | `PresetId` | `Wade` | Id to identify the selected preset. A owner might define multiple presets |
 | `BluetoothEnabled` | `1` | 1 if bluetooth is enabled, 0 otherwise
 | `TrackId` | `38605ba-76...` | A uuid that can be used to uniquely identify the track.
+| `TimeZone` | `GPS` | The time zone used to write Date and Time data. Typically this is GPS which is some leap seconds ahead of UTC (as of today 18)
 
 ## CSV
 
@@ -82,7 +83,7 @@ Based on http://dataprotocols.org/csv-dialect/ the definition is:
 
 Headline    | Format | Range | Sample | Description |
 ---         | --- | --- | --- | --- |
-`Date`      | TT.MM.YYYY | | 24.11.2020 | GPS, typically as received by the GPS module in that second. If there is no GPS module present, system time is used. If there was no reception of a time signal yet, this might be unix time (starting 1.1.1970) which can be used as offset between the csv lines. Expect none linearity when time is set.    
+`Date`      | TT.MM.YYYY | | 24.11.2020 | See `TimeZone` above. GPS, typically as received by the GPS module in that second. If there is no GPS module present, system time is used. If there was no reception of a time signal yet, this might be unix time (starting 1.1.1970) which can be used as offset between the csv lines. Expect none linearity when time is set.    
 `Time`      | HH:MM:SS | | 12:00:00 | GPS time, see also above, GPS time is as of today 18 seconds ahead of UTC
 `Millis`    | int32  | 0-2^31 | 1234567 | Millisecond counter will continuously increase throughout the file, for time difference calculation
 `Comment`   | char[] |  |  | Space to leave a short text comment 

--- a/docs/software/firmware/csv_format.md
+++ b/docs/software/firmware/csv_format.md
@@ -39,7 +39,7 @@ understand.
 | `PresetId` | `Wade` | Id to identify the selected preset. A owner might define multiple presets |
 | `BluetoothEnabled` | `1` | 1 if bluetooth is enabled, 0 otherwise
 | `TrackId` | `38605ba-76...` | A uuid that can be used to uniquely identify the track.
-| `TimeZone` | `GPS` | The time zone used to write Date and Time data. Typically this is GPS which is some leap seconds ahead of UTC (as of today 18)
+| `TimeZone` | `GPS` | The time zone used to write Date and Time data. Typically this is GPS which is some leap seconds ahead of UTC (as of today 18). UTC is also a allowed value and the default if not TimeZone is given.
 
 ## CSV
 
@@ -83,8 +83,8 @@ Based on http://dataprotocols.org/csv-dialect/ the definition is:
 
 Headline    | Format | Range | Sample | Description |
 ---         | --- | --- | --- | --- |
-`Date`      | TT.MM.YYYY | | 24.11.2020 | See `TimeZone` above. GPS, typically as received by the GPS module in that second. If there is no GPS module present, system time is used. If there was no reception of a time signal yet, this might be unix time (starting 1.1.1970) which can be used as offset between the csv lines. Expect none linearity when time is set.    
-`Time`      | HH:MM:SS | | 12:00:00 | GPS time, see also above, GPS time is as of today 18 seconds ahead of UTC
+`Date`      | TT.MM.YYYY | | 24.11.2020 | Time, typically as received by the GPS module. If there was no reception of a time signal yet, this might be unix time (starting 1.1.1970) which can be used as offset between the csv lines. Expect none linearity when time is set.    
+`Time`      | HH:MM:SS | | 12:00:00 | TimeZone is GPS or UTC according to the TimeZone metadata.
 `Millis`    | int32  | 0-2^31 | 1234567 | Millisecond counter will continuously increase throughout the file, for time difference calculation
 `Comment`   | char[] |  |  | Space to leave a short text comment 
 `Latitude`  | double | -90.0-90.0 | 42.123456 | Latitude as degrees

--- a/docs/software/firmware/csv_format.md
+++ b/docs/software/firmware/csv_format.md
@@ -87,8 +87,8 @@ Headline    | Format | Range | Sample | Description |
 `Time`      | HH:MM:SS | | 12:00:00 | GPS time, see also above, GPS time is as of today 18 seconds ahead of UTC
 `Millis`    | int32  | 0-2^31 | 1234567 | Millisecond counter will continuously increase throughout the file, for time difference calculation
 `Comment`   | char[] |  |  | Space to leave a short text comment 
-`Latitude`  | double | -90.0-90.0 | 9.123456 | Latitude as degrees
-`Longitude` | double | -180.0-180.0 | 42.123456 | Longitude in degrees
+`Latitude`  | double | -90.0-90.0 | 42.123456 | Latitude as degrees
+`Longitude` | double | -180.0-180.0 | 9.123456 | Longitude in degrees
 `Altitude`  | double | -9999.9-17999.9 | 480.12 | meters above mean sea level (GPGGA)
 `Course`    | double | 0-359.9 | 42 | Course over ground in degrees (GPRMC)
 `Speed`     | double | 0-359.9 | 42.0 | Speed over ground in km/h

--- a/docs/software/firmware/csv_format.md
+++ b/docs/software/firmware/csv_format.md
@@ -82,8 +82,8 @@ Based on http://dataprotocols.org/csv-dialect/ the definition is:
 
 Headline    | Format | Range | Sample | Description |
 ---         | --- | --- | --- | --- |
-`Date`      | TT.MM.YYYY | | 24.11.2020 | UTC, typically as received by the GPS module in that second. If there is no GPS module present, system time is used. If there was no reception of a time signal yet, this might be unix time (starting 1.1.1970) which can be used as offset between the csv lines. Expect none linearity when time is set.    
-`Time`      | HH:MM:SS | | 12:00:00 | UTC time, see also above
+`Date`      | TT.MM.YYYY | | 24.11.2020 | GPS, typically as received by the GPS module in that second. If there is no GPS module present, system time is used. If there was no reception of a time signal yet, this might be unix time (starting 1.1.1970) which can be used as offset between the csv lines. Expect none linearity when time is set.    
+`Time`      | HH:MM:SS | | 12:00:00 | GPS time, see also above, GPS time is as of today 18 seconds ahead of UTC
 `Millis`    | int32  | 0-2^31 | 1234567 | Millisecond counter will continuously increase throughout the file, for time difference calculation
 `Comment`   | char[] |  |  | Space to leave a short text comment 
 `Latitude`  | double | -90.0-90.0 | 9.123456 | Latitude as degrees

--- a/docs/software/firmware/obs_cfg.md
+++ b/docs/software/firmware/obs_cfg.md
@@ -37,9 +37,6 @@ relevant put the order of the array content.
           // Bitfield display config, see DisplayOptions for details, 
           // as noted all subject to change!
             "displayConfig": 15,
-          // For what GPS fix should the OBS wait at startup?
-          // -2: FIX POS; -1: Time only; 0: No wait
-            "gpsFix": -2,
           // PIN to be entered when accessing the OBS web interface.
           // a new one will be created when empty. The PIN is also displayed 
           // on the OBS display when needed.

--- a/src/OpenBikeSensorFirmware.cpp
+++ b/src/OpenBikeSensorFirmware.cpp
@@ -325,8 +325,7 @@ void setup() {
   gps.handle();
   gps.setStatisticsIntervalInSeconds(1); // get regular updates.
 
-  int gpsWaitFor = cfg.getProperty<int>(ObsConfig::PROPERTY_GPS_FIX);
-  while (!gps.hasState(gpsWaitFor, displayTest)) {
+  while (!gps.hasFix(displayTest)) {
     currentTimeMillis = millis();
     gps.handle();
     sensorManager->getDistances();
@@ -345,9 +344,9 @@ void setup() {
   // now we have a fix only rate updates, could be set to 0?
   gps.setStatisticsIntervalInSeconds(0);
 
-  gps.handle(1000); // Added for user experience
-  gps.pollStatistics();
   gps.enableSbas();
+  gps.handle(1100); // Added for user experience
+  gps.pollStatistics();
   displayTest->clear();
 }
 
@@ -410,7 +409,7 @@ void loop() {
   if (startTimeMillis == 0) {
     startTimeMillis = (currentTimeMillis / measureInterval) * measureInterval;
   }
-  currentSet->time = Gps::currentTime();
+  currentSet->time = time(nullptr);
   currentSet->millis = currentTimeMillis;
   currentSet->batteryLevel = voltageMeter->read();
   currentSet->isInsidePrivacyArea = gps.isInsidePrivacyArea();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -44,7 +44,6 @@ const String ObsConfig::PROPERTY_WIFI_SSID = String("wifiSsid");
 const String ObsConfig::PROPERTY_WIFI_PASSWORD = String("wifiPassword");
 const String ObsConfig::PROPERTY_PORTAL_URL = String("portalUrl");
 const String ObsConfig::PROPERTY_PORTAL_TOKEN = String("portalToken");
-const String ObsConfig::PROPERTY_GPS_FIX = String("gpsFix");
 const String ObsConfig::PROPERTY_DISPLAY_CONFIG = String("displayConfig");
 const String ObsConfig::PROPERTY_CONFIRMATION_TIME_SECONDS = String("confirmationTimeSeconds");
 const String ObsConfig::PROPERTY_PRIVACY_CONFIG = String("privacyConfig");
@@ -148,7 +147,6 @@ void ObsConfig::makeSureSystemDefaultsAreSet() {
     setProperty(0, PROPERTY_PORTAL_TOKEN, "");
   }
   ensureSet(data, PROPERTY_PORTAL_TOKEN, "");
-  ensureSet(data, PROPERTY_GPS_FIX, (int) Gps::WaitFor::FIX_POS);
   ensureSet(data, PROPERTY_DISPLAY_CONFIG, DisplaySimple);
   if (getProperty<int>(PROPERTY_DISPLAY_CONFIG) == 0) {
     data[PROPERTY_DISPLAY_CONFIG] = DisplaySimple;
@@ -399,17 +397,6 @@ void ObsConfig::parseOldJsonDocument(DynamicJsonDocument &doc) {
   setProperty(0, PROPERTY_WIFI_PASSWORD, doc["password"] | String("Freifunk"));
   setProperty(0, PROPERTY_PORTAL_TOKEN, doc["obsUserID"] | String("5e8f2f43e7e3b3668ca13151"));
   setProperty(0, PROPERTY_DISPLAY_CONFIG, doc["displayConfig"] | DisplaySimple);
-
-  uint16_t gpsConfig = doc["GPSConfig"];
-  if (gpsConfig & GPSOptions::ValidTime) {
-    setProperty(0, PROPERTY_GPS_FIX, (int) Gps::WaitFor::FIX_TIME);
-  } else if (gpsConfig & GPSOptions::ValidLocation) {
-    setProperty(0, PROPERTY_GPS_FIX, (int) Gps::WaitFor::FIX_POS);
-  } else if (gpsConfig & GPSOptions::NumberSatellites) {
-    setProperty(0, PROPERTY_GPS_FIX, doc["satsForFix"] | 4);
-  } else {
-    setProperty(0, PROPERTY_GPS_FIX, (int) Gps::WaitFor::FIX_NO_WAIT);
-  }
   setProperty(0, PROPERTY_CONFIRMATION_TIME_SECONDS, doc["confirmationTimeWindow"] | 5);
   setProperty(0, PROPERTY_PRIVACY_CONFIG, doc["privacyConfig"] | AbsolutePrivacy);
   setProperty(0, PROPERTY_BLUETOOTH, doc["bluetooth"] | false);

--- a/src/config.h
+++ b/src/config.h
@@ -132,7 +132,6 @@ class ObsConfig {
     static const String PROPERTY_WIFI_PASSWORD;
     static const String PROPERTY_PORTAL_TOKEN;
     static const String PROPERTY_PORTAL_URL;
-    static const String PROPERTY_GPS_FIX;
     static const String PROPERTY_DISPLAY_CONFIG;
     static const String PROPERTY_CONFIRMATION_TIME_SECONDS;
     static const String PROPERTY_PRIVACY_CONFIG;

--- a/src/configServer.cpp
+++ b/src/configServer.cpp
@@ -309,14 +309,6 @@ static const char* const configIndex =
   "<hr>"
   "Swap Sensors (Left &#8660; Right)<input type='checkbox' name='displaySwapSensors' {displaySwapSensors}>"
   ""
-  "<h3>GPS</h3>"
-  "<label for='gpsFix'>GPS to wait for</label> "
-  "<select id='gpsFix' name='gpsFix'>"
-  "<option value='-2' {fixPos}>position</option>"
-  "<option value='-1' {fixTime}>time only</option>"
-  "<option value='0' {fixNoWait}>no wait</option>"
-  "</select>"
-  ""
   "<h3>Generic Display</h3>"
   "Invert<br>(black &#8660; white)<input type='checkbox' name='displayInvert' {displayInvert}>"
   "<hr>"
@@ -1094,9 +1086,6 @@ static void handleConfigSave(HTTPRequest * req, HTTPResponse * res) {
   offsets.push_back(atoi(getParameter(params, "offsetS1").c_str()));
   theObsConfig->setOffsets(0, offsets);
 
-  theObsConfig->setProperty(0, ObsConfig::PROPERTY_GPS_FIX,
-                            atoi(getParameter(params, "gpsFix").c_str()));
-
   // TODO: cleanup
   const String privacyOptions = getParameter(params, "privacyOptions");
   const String overridePrivacy = getParameter(params, "overridePrivacy");
@@ -1159,11 +1148,6 @@ static void handleConfig(HTTPRequest *, HTTPResponse * res) {
                theObsConfig->getProperty<bool>(ObsConfig::PROPERTY_BLUETOOTH) ? "checked" : "");
   html = replaceHtml(html, "{simRaMode}",
                theObsConfig->getProperty<bool>(ObsConfig::PROPERTY_SIM_RA) ? "checked" : "");
-
-  int gpsFix = theObsConfig->getProperty<int>(ObsConfig::PROPERTY_GPS_FIX);
-  html = replaceHtml(html, "{fixPos}", gpsFix == (int) Gps::WaitFor::FIX_POS || gpsFix > 0 ? "selected" : "");
-  html = replaceHtml(html, "{fixTime}", gpsFix == (int) Gps::WaitFor::FIX_TIME ? "selected" : "");
-  html = replaceHtml(html, "{fixNoWait}", gpsFix == (int) Gps::WaitFor::FIX_NO_WAIT ? "selected" : "");
 
   const uint privacyConfig = (uint) theObsConfig->getProperty<int>(
     ObsConfig::PROPERTY_PRIVACY_CONFIG);

--- a/src/configServer.cpp
+++ b/src/configServer.cpp
@@ -32,10 +32,11 @@
 #include <HTTPURLEncodedBodyParser.hpp>
 #include <esp_ota_ops.h>
 #include <esp_partition.h>
-#include <utils/https.h>
 #include "SPIFFS.h"
 #include "HTTPMultipartBodyParser.hpp"
 #include "Firmware.h"
+#include "utils/https.h"
+#include "utils/timeutils.h"
 
 using namespace httpsserver;
 
@@ -702,7 +703,7 @@ void startServer(ObsConfig *obsConfig) {
 
   MDNS.begin("obs");
 
-  ObsUtils::setClockByNtp(WiFi.gatewayIP().toString().c_str());
+  TimeUtils::setClockByNtp(WiFi.gatewayIP().toString().c_str());
   if (!voltageMeter) {
     voltageMeter = new VoltageMeter();
   }
@@ -848,13 +849,13 @@ static void handleAbout(HTTPRequest *req, HTTPResponse * res) {
     files += " ";
     files += ObsUtils::toScaledByteString(file.size());
     files += " ";
-    files += ObsUtils::dateTimeToString(file.getLastWrite());
+    files += TimeUtils::dateTimeToString(file.getLastWrite());
     file.close();
     file = dir.openNextFile();
   }
   dir.close();
   page += keyValue("SPIFFS files", files);
-  page += keyValue("System date time", ObsUtils::dateTimeToString(file.getLastWrite()));
+  page += keyValue("System date time", TimeUtils::dateTimeToString(file.getLastWrite()));
   page += keyValue("System millis", String(millis()));
 
   if (voltageMeter) {
@@ -1567,7 +1568,7 @@ static void handleSd(HTTPRequest *req, HTTPResponse *res) {
 
       auto fileName = String(child.name());
       auto fileTip = ObsUtils::encodeForXmlAttribute(
-        ObsUtils::dateTimeToString(child.getLastWrite())
+        TimeUtils::dateTimeToString(child.getLastWrite())
         + " - " + ObsUtils::toScaledByteString(child.size()));
 
       fileName = fileName.substring(int(fileName.lastIndexOf("/") + 1));

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -537,22 +537,17 @@ void Gps::showWaitStatus(SSD1306DisplayDevice *display) const {
   if (mValidMessagesReceived == 0) { // could not get any valid char from GPS module
     satellitesString[0] = "OFF?";
   } else if (mLastTimeTimeSet == 0) {
-    satellitesString[0] = "no time " + String(mLastNoiseLevel);
+    satellitesString[0] = String(mCurrentGpsRecord.mSatellitesUsed) + "sats SN:" + String(mLastNoiseLevel);
   } else {
-    satellitesString[0] = ObsUtils::timeToString();
+    satellitesString[0] = "GPS " + ObsUtils::timeToString();
     satellitesString[1] = String(mCurrentGpsRecord.mSatellitesUsed) + "sats SN:" + String(mLastNoiseLevel);
   }
 
-  if (mValidMessagesReceived != 0    //only do this if a communication is there and a valid time is there
-      && mLastTimeTimeSet != 0) {
-    // This is a hack :) if still the "Wait for GPS" version is displayed original line
-    if (displayTest->get_gridTextofCell(2, 4).startsWith("Wait")) {
-      display->newLine();
-    }
+  if (satellitesString[1].isEmpty()) {
+    displayTest->showTextOnGrid(2, display->currentLine(), satellitesString[0]);
+  } else {
     displayTest->showTextOnGrid(2, display->currentLine() - 1, satellitesString[0]);
     displayTest->showTextOnGrid(2, display->currentLine(), satellitesString[1]);
-  } else { //if no gps comm or no time is there, just write in the last row
-    displayTest->showTextOnGrid(2, display->currentLine(), satellitesString[0]);
   }
 }
 

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -268,7 +268,9 @@ bool Gps::setMessageInterval(UBX_MSG msgId, uint8_t seconds, bool waitForAck) {
 bool Gps::setBaud() {
   mSerial.end();
   mSerial.begin(115200, SERIAL_8N1);
-  mSerial.setRxBufferSize(512); // FIXME only while supporting UBX && NMEA
+  mSerial.setRxBufferSize(512);
+  while(mSerial.read() >= 0) ;
+
   if (checkCommunication()) {
     log_i("GPS startup already 115200");
     return true;
@@ -370,9 +372,9 @@ bool Gps::handle() {
 
   boolean gotGpsData = false;
   int bytesProcessed = 0;
-  while (mSerial.available() > 0) {
+  int data;
+  while ((data = mSerial.read()) >= 0) {
     bytesProcessed++;
-    int data = mSerial.read();
     if (encode(data)) {
       gotGpsData = true;
       if (bytesProcessed > 1024) {

--- a/src/gps.h
+++ b/src/gps.h
@@ -47,10 +47,7 @@ class Gps {
     /* read and process data from serial, true if there was valid data. */
     bool handle();
 
-    /* Returns the current time - GPS time if available, system time otherwise. */
-    static time_t currentTime();
-
-    bool hasState(int state, SSD1306DisplayDevice *display) const;
+    bool hasFix(SSD1306DisplayDevice *display) const;
 
     /* Returns true if valid communication with the gps module was possible. */
     bool moduleIsAlive() const;
@@ -510,9 +507,9 @@ class Gps {
 
     void checkGpsDataState();
 
-    static uint32_t timeToTimeOfWeek(time_t t);
+    static uint32_t utcTimeToTimeOfWeek(time_t t);
 
-    static uint16_t timeToWeekNumber(time_t t);
+    static uint16_t utcTimeToWeekNumber(time_t t);
 
     void softResetGps();
 

--- a/src/gps.h
+++ b/src/gps.h
@@ -86,8 +86,6 @@ class Gps {
     void handle(uint32_t milliSeconds);
 
     static PrivacyArea newPrivacyArea(double latitude, double longitude, int radius);
-    static int16_t getLeapSecondsGps(time_t gps);
-    static int16_t getLeapSecondsUtc(time_t gps);
 
     void enableSbas();
 
@@ -526,10 +524,6 @@ class Gps {
 
     static void randomOffset(PrivacyArea &p);
 
-    static time_t gpsDayToTime(uint16_t week, uint16_t dayOfWeek);
-
-    static time_t toTime(uint16_t week, uint32_t weekTime);
-
     static bool validNmeaMessageChar(uint8_t chr);
 
     bool setMessageInterval(UBX_MSG msgId, uint8_t seconds, bool waitForAck = true);
@@ -537,10 +531,6 @@ class Gps {
     bool prepareGpsData(uint32_t tow);
 
     void checkGpsDataState();
-
-    static uint32_t utcTimeToTimeOfWeek(time_t t);
-
-    static uint16_t utcTimeToWeekNumber(time_t t);
 
     void softResetGps();
 

--- a/src/gps.h
+++ b/src/gps.h
@@ -404,7 +404,7 @@ class Gps {
           PREV_TM = 1 << 7,
         } flags;
       } aidIni;
-      struct __attribute__((__packed__)) AID_HUI {
+      struct __attribute__((__packed__)) AidHui {
         UBX_HEADER ubxHeader;
         uint32_t health;
         double utcA0;
@@ -424,7 +424,7 @@ class Gps {
         float klobB1;
         float klobB2;
         float klobB3;
-        enum class FLAGS : uint32_t {
+        enum class Flags : uint32_t {
           health = 1,
           utc = 1 << 1,
           klob = 1 << 2,
@@ -536,6 +536,7 @@ class Gps {
 
     void handleUbxNavTimeGps(const GpsBuffer::UbxNavTimeGps & message, const uint32_t receivedMs, const uint32_t delayMs);
     void handleUbxAidIni(const GpsBuffer::AidIni &message) const;
+    void handleUbxAidHui(const GpsBuffer::AidHui &massage) const;
 };
 
 #endif

--- a/src/gps.h
+++ b/src/gps.h
@@ -86,6 +86,8 @@ class Gps {
     void handle(uint32_t milliSeconds);
 
     static PrivacyArea newPrivacyArea(double latitude, double longitude, int radius);
+    static int16_t getLeapSecondsGps(time_t gps);
+    static int16_t getLeapSecondsUtc(time_t gps);
 
     void enableSbas();
 
@@ -160,6 +162,7 @@ class Gps {
 
         // AID 0x0B
         AID_INI = 0x010B,
+        AID_HUI = 0x020B,
         AID_ALPSRV = 0x320B,
         AID_ALP = 0x500B,
 
@@ -403,6 +406,32 @@ class Gps {
           PREV_TM = 1 << 7,
         } flags;
       } aidIni;
+      struct __attribute__((__packed__)) AID_HUI {
+        UBX_HEADER ubxHeader;
+        uint32_t health;
+        double utcA0;
+        double utcA1;
+        int32_t utcTOW;
+        int16_t utcWNT;
+        int16_t utcLS;
+        int16_t utcWNF;
+        int16_t utcDN;
+        int16_t utcLSF;
+        int16_t utcSpare;
+        float klobA0;
+        float klobA1;
+        float klobA2;
+        float klobA3;
+        float klobB0;
+        float klobB1;
+        float klobB2;
+        float klobB3;
+        enum class FLAGS : uint32_t {
+          health = 1,
+          utc = 1 << 1,
+          klob = 1 << 2,
+        } flags;
+      } aidHui;
       struct __attribute__((__packed__)) {
         UBX_HEADER ubxHeader;
         uint8_t idSize;
@@ -496,6 +525,8 @@ class Gps {
     static double haversine(double lat1, double lon1, double lat2, double lon2);
 
     static void randomOffset(PrivacyArea &p);
+
+    static time_t gpsDayToTime(uint16_t week, uint16_t dayOfWeek);
 
     static time_t toTime(uint16_t week, uint32_t weekTime);
 

--- a/src/gps.h
+++ b/src/gps.h
@@ -56,7 +56,7 @@ class Gps {
 
     uint8_t getValidSatellites() const;
 
-    void showWaitStatus(SSD1306DisplayDevice *display) const;
+    void showWaitStatus(const SSD1306DisplayDevice *display) const;
 
     /* Returns current speed, negative value means unknown speed. */
     double getSpeed() const;
@@ -335,7 +335,7 @@ class Gps {
         uint32_t sAcc;
         uint32_t cAcc;
       } navVelned;
-      struct __attribute__((__packed__)) {
+      struct __attribute__((__packed__)) UbxNavTimeGps {
         UBX_HEADER ubxHeader;
         uint32_t iTow;
         int32_t fTow;
@@ -379,7 +379,7 @@ class Gps {
         uint32_t reserved2;
         uint32_t reserved3;
       } navAopStatus;
-      struct __attribute__((__packed__)) AID_INI {
+      struct __attribute__((__packed__)) AidIni {
         UBX_HEADER ubxHeader;
         int32_t ecefXorLat;
         int32_t ecefYorLon;
@@ -534,6 +534,8 @@ class Gps {
 
     void softResetGps();
 
+    void handleUbxNavTimeGps(const GpsBuffer::UbxNavTimeGps & message, const uint32_t receivedMs, const uint32_t delayMs);
+    void handleUbxAidIni(const GpsBuffer::AidIni &message) const;
 };
 
 #endif

--- a/src/uploader.cpp
+++ b/src/uploader.cpp
@@ -26,6 +26,7 @@
 #include "globals.h"
 #include "utils/multipart.h"
 #include "utils/cacerts.h"
+#include "utils/timeutils.h"
 #include "writer.h"
 
 static char const *const HTTP_LOCATION_HEADER = "location";
@@ -33,7 +34,7 @@ static char const *const HTTP_LOCATION_HEADER = "location";
 Uploader::Uploader(String portalUrl, String userToken) :
     mPortalUrl(std::move(portalUrl)),
     mPortalUserToken(std::move(userToken)) {
-  ObsUtils::setClockByNtpAndWait();
+  TimeUtils::setClockByNtpAndWait();
   mWiFiClient.setCACert(trustedRootCACertificates);
 }
 

--- a/src/utils/alpdata.cpp
+++ b/src/utils/alpdata.cpp
@@ -25,6 +25,7 @@
 #include <HTTPUpdate.h>
 #include "globals.h"
 #include "alpdata.h"
+#include "timeutils.h"
 
 /* Download http://alp.u-blox.com/current_14d.alp (ssl?) if there is a new one
  * Takes 5 seconds to update the data.
@@ -35,19 +36,19 @@ void AlpData::update(SSD1306DisplayDevice *display) {
   File f = SD.open(ALP_DATA_FILE_NAME, FILE_READ);
   if (!f || f.size() < ALP_DATA_MIN_FILE_SIZE ) {
     lastModified = "";
-  } else if (f.getLastWrite() > ObsUtils::PAST_TIME &&
+  } else if (f.getLastWrite() > TimeUtils::PAST_TIME &&
     (f.getLastWrite() + 4 * 24  * 60 * 60) > time(nullptr)) {
     log_d("File still current %s",
-          ObsUtils::dateTimeToString(f.getLastWrite()).c_str());
+          TimeUtils::dateTimeToString(f.getLastWrite()).c_str());
     log_d("Now: %s",
-          ObsUtils::dateTimeToString(time(nullptr)).c_str());
+          TimeUtils::dateTimeToString(time(nullptr)).c_str());
     log_d("Next Update: %s",
-          ObsUtils::dateTimeToString(f.getLastWrite() + 4 * 24  * 60 * 60).c_str());
+          TimeUtils::dateTimeToString(f.getLastWrite() + 4 * 24 * 60 * 60).c_str());
     f.close();
     return;
   }
   f.close();
-  log_d("Existing file last write %s", ObsUtils::dateTimeToString(f.getLastWrite()).c_str());
+  log_d("Existing file last write %s", TimeUtils::dateTimeToString(f.getLastWrite()).c_str());
   log_d("Existing file is from %s", lastModified.c_str());
   display->showTextOnGrid(0, 5, "ALP data ...");
 

--- a/src/utils/alpdata.cpp
+++ b/src/utils/alpdata.cpp
@@ -144,7 +144,7 @@ uint16_t AlpData::fill(uint8_t *data, size_t ofs, uint16_t dataSize) {
   return read;
 }
 
-/* Used to save AID_INI data. */
+/* Used to save AidIni data. */
 void AlpData::saveMessage(const uint8_t *data, size_t size) {
   File f = SD.open(AID_INI_DATA_FILE_NAME, FILE_WRITE);
   if (f) {
@@ -158,7 +158,7 @@ void AlpData::saveMessage(const uint8_t *data, size_t size) {
   }
 }
 
-/* Used to save AID_INI data. */
+/* Used to save AidIni data. */
 size_t AlpData::loadMessage(uint8_t *data, size_t size) {
   size_t result = 0;
   File f = SD.open(AID_INI_DATA_FILE_NAME, FILE_READ);

--- a/src/utils/obsutils.cpp
+++ b/src/utils/obsutils.cpp
@@ -30,75 +30,10 @@ static const uint32_t BYTES_PER_KIB = 1 << 10;
 static const uint32_t BYTES_PER_MIB = 1 << 20;
 static const uint32_t BYTES_PER_GIB = 1 << 30;
 
-const time_t ObsUtils::PAST_TIME = 30 * 365 * 24 * 60 * 60;
-
 String ObsUtils::createTrackUuid() {
   uint8_t data[16];
   esp_fill_random(data, 16);
   return String(BLEUUID(data, 16, false).toString().c_str());
-}
-
-String ObsUtils::dateTimeToString(time_t theTime) {
-  char date[32];
-  if (theTime == 0) {
-    theTime = time(nullptr);
-  }
-  tm timeStruct;
-  localtime_r(&theTime, &timeStruct);
-  snprintf(date, sizeof(date),
-           "%04d-%02d-%02dT%02d:%02d:%02d",
-           timeStruct.tm_year + 1900, timeStruct.tm_mon + 1, timeStruct.tm_mday,
-           timeStruct.tm_hour, timeStruct.tm_min, timeStruct.tm_sec);
-  return String(date);
-}
-
-String ObsUtils::timeToString(time_t theTime) {
-  char date[32];
-  if (theTime == 0) {
-    theTime = time(nullptr);
-  }
-  tm timeStruct;
-  localtime_r(&theTime, &timeStruct);
-  snprintf(date, sizeof(date),
-           "%02d:%02d:%02d",
-           timeStruct.tm_hour, timeStruct.tm_min, timeStruct.tm_sec);
-  return String(date);
-}
-
-String ObsUtils::dateTimeToHttpHeaderString(time_t theTime) {
-  char date[32];
-  if (theTime == 0) {
-    theTime = time(nullptr);
-  }
-  tm timeStruct;
-  localtime_r(&theTime, &timeStruct);
-  snprintf(date, sizeof(date),
-           "%s, %02d %s %04d %02d:%02d:%02d GMT",
-           weekDayToString(timeStruct.tm_wday),
-           timeStruct.tm_mday,
-           monthToString(timeStruct.tm_mon),
-           timeStruct.tm_year + 1900,
-           timeStruct.tm_hour, timeStruct.tm_min, timeStruct.tm_sec);
-  return String(date);
-}
-
-const char *ObsUtils::WEEK_DAYS[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
-const char *ObsUtils::MONTHS[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
-
-const char* ObsUtils::weekDayToString(uint8_t wDay) {
-  if (wDay > 6) {
-    return "???";
-  } else {
-    return WEEK_DAYS[wDay];
-  }
-}
-
-const char* ObsUtils::monthToString(uint8_t mon) {
-  if (mon > 11) {
-    return "???";
-  } else {
-    return MONTHS[mon];
-  }
 }
 
 String ObsUtils::stripCsvFileName(const String &fileName) {
@@ -109,39 +44,6 @@ String ObsUtils::stripCsvFileName(const String &fileName) {
       0, userPrintableFilename.length() - CSVFileWriter::EXTENSION.length());
   }
   return userPrintableFilename;
-}
-
-void ObsUtils::setClockByNtp(const char* ntpServer) {
-  if (!systemTimeIsSet()) {
-    if (ntpServer) {
-      log_d("Got additional NTP Server %s.", ntpServer);
-      configTime(
-        0, 0, ntpServer,
-        "rustime01.rus.uni-stuttgart.de", "pool.ntp.org");
-    } else {
-      configTime(
-        0, 0,
-        "rustime01.rus.uni-stuttgart.de", "pool.ntp.org");
-    }
-  }
-}
-
-void ObsUtils::setClockByNtpAndWait(const char* ntpServer) {
-  setClockByNtp(ntpServer);
-
-  log_d("Waiting for NTP time sync: ");
-  while (!systemTimeIsSet()) {
-    delay(500);
-    log_v(".");
-    yield();
-  }
-  log_d("NTP time set got %s.", ObsUtils::dateTimeToString(time(nullptr)).c_str());
-}
-
-bool ObsUtils::systemTimeIsSet() {
-  time_t now = time(nullptr);
-  log_v("NTP time %s.", ObsUtils::dateTimeToString(now).c_str());
-  return now > 1609681614;
 }
 
 String ObsUtils::encodeForXmlAttribute(const String &text) {

--- a/src/utils/obsutils.cpp
+++ b/src/utils/obsutils.cpp
@@ -46,7 +46,7 @@ String ObsUtils::dateTimeToString(time_t theTime) {
   tm timeStruct;
   localtime_r(&theTime, &timeStruct);
   snprintf(date, sizeof(date),
-           "%04d-%02d-%02dT%02d:%02d:%02dZ",
+           "%04d-%02d-%02dT%02d:%02d:%02d",
            timeStruct.tm_year + 1900, timeStruct.tm_mon + 1, timeStruct.tm_mday,
            timeStruct.tm_hour, timeStruct.tm_min, timeStruct.tm_sec);
   return String(date);
@@ -60,7 +60,7 @@ String ObsUtils::timeToString(time_t theTime) {
   tm timeStruct;
   localtime_r(&theTime, &timeStruct);
   snprintf(date, sizeof(date),
-           "%02d:%02d:%02dZ",
+           "%02d:%02d:%02d",
            timeStruct.tm_hour, timeStruct.tm_min, timeStruct.tm_sec);
   return String(date);
 }

--- a/src/utils/obsutils.h
+++ b/src/utils/obsutils.h
@@ -32,8 +32,6 @@
 class ObsUtils {
   public:
     static String createTrackUuid();
-    static String dateTimeToString(time_t time = 0);
-    static String timeToString(time_t theTime =0);
     static String sha256ToString(byte *sha256);
     /* Strips technical details like extension or '/' from the file name. */
     static String stripCsvFileName(const String &fileName);
@@ -41,19 +39,8 @@ class ObsUtils {
     static String encodeForXmlText(const String &text);
     static String encodeForCsvField(const String &field);
     static String encodeForUrl(const String &url);
-    static void setClockByNtp(const char *ntpServer = nullptr);
-    static void setClockByNtpAndWait(const char *ntpServer = nullptr);
-    static bool systemTimeIsSet();
     static String toScaledByteString(uint64_t size);
-    static String dateTimeToHttpHeaderString(time_t theTime);
     static void logHexDump(const uint8_t *buffer, uint16_t length);
-    static const time_t PAST_TIME;
-
-  private:
-    static const char *weekDayToString(uint8_t wDay);
-    static const char *monthToString(uint8_t mon);
-    static const char *WEEK_DAYS[7];
-    static const char *MONTHS[12];
 
 };
 

--- a/src/utils/timeutils.cpp
+++ b/src/utils/timeutils.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2019-2021 OpenBikeSensor Contributors
+ * Contact: https://openbikesensor.org
+ *
+ * This file is part of the OpenBikeSensor firmware.
+ *
+ * The OpenBikeSensor firmware is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * OpenBikeSensor firmware is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with the OpenBikeSensor firmware.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+#include "timeutils.h"
+
+#include <time.h>
+#include <sys/time.h>
+
+
+/* Flag character used when time was set according to GPS Time */
+static const char TIMEZONE_GPS = ' ';
+/* Flag character used when time was set according to UTC Time */
+static const char TIMEZONE_UTC = 'Z';
+/* Flag character used when time was not set */
+static const char TIMEZONE_UNKNOWN = 'X';
+
+// remember last timezone used, need to do it manually because GPS is not a
+// TimeZone in sense of linux supported time zones.
+static char timeZone = TIMEZONE_UNKNOWN;
+
+
+const uint32_t TimeUtils::SECONDS_PER_DAY = 60L * 60 * 24;
+const uint32_t TimeUtils::SECONDS_PER_WEEK = SECONDS_PER_DAY * 7;
+// use difftime() ?
+/* GPS Start time is 1980-01-06T00:00:00Z  */
+const uint32_t TimeUtils::GPS_EPOCH_OFFSET = 315964800L;
+
+
+const time_t TimeUtils::PAST_TIME = 30 * 365 * 24 * 60 * 60;
+const char *TimeUtils::WEEK_DAYS[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
+const char *TimeUtils::MONTHS[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+
+
+String TimeUtils::dateTimeToString(time_t timeIn) {
+  char date[32];
+  time_t theTime;
+  if (timeIn == 0) {
+    theTime = time(nullptr);
+  } else {
+    theTime = timeIn;
+  }
+  tm timeStruct;
+  localtime_r(&theTime, &timeStruct);
+  snprintf(date, sizeof(date),
+           "%04d-%02d-%02dT%02d:%02d:%02d",
+           timeStruct.tm_year + 1900, timeStruct.tm_mon + 1, timeStruct.tm_mday,
+           timeStruct.tm_hour, timeStruct.tm_min, timeStruct.tm_sec);
+  String result(date);
+  if (timeIn == 0 && timeZone == TIMEZONE_UTC) {
+    result += TIMEZONE_UTC;
+  }
+  return result;
+}
+
+String TimeUtils::timeToString(time_t timeIn) {
+  char date[32];
+  time_t theTime;
+  if (timeIn == 0) {
+    theTime = time(nullptr);
+  } else {
+    theTime = timeIn;
+  }
+  if (theTime == 0) {
+    theTime = time(nullptr);
+  }
+  tm timeStruct;
+  localtime_r(&theTime, &timeStruct);
+  snprintf(date, sizeof(date),
+           "%02d:%02d:%02d",
+           timeStruct.tm_hour, timeStruct.tm_min, timeStruct.tm_sec);
+  String result(date);
+  if (timeIn == 0 && timeZone == TIMEZONE_UTC) {
+    result += TIMEZONE_UTC;
+  }
+  return result;
+}
+
+String TimeUtils::dateTimeToHttpHeaderString(time_t theTime) {
+  char date[32];
+  if (theTime == 0) {
+    theTime = time(nullptr);
+  }
+  tm timeStruct;
+  localtime_r(&theTime, &timeStruct);
+  snprintf(date, sizeof(date),
+           "%s, %02d %s %04d %02d:%02d:%02d GMT",
+           weekDayToString(timeStruct.tm_wday),
+           timeStruct.tm_mday,
+           monthToString(timeStruct.tm_mon),
+           timeStruct.tm_year + 1900,
+           timeStruct.tm_hour, timeStruct.tm_min, timeStruct.tm_sec);
+  return String(date);
+}
+
+const char* TimeUtils::weekDayToString(uint8_t wDay) {
+  if (wDay > 6) {
+    return "???";
+  } else {
+    return WEEK_DAYS[wDay];
+  }
+}
+
+const char* TimeUtils::monthToString(uint8_t mon) {
+  if (mon > 11) {
+    return "???";
+  } else {
+    return MONTHS[mon];
+  }
+}
+
+void TimeUtils::setClockByNtp(const char* ntpServer) {
+  if (!systemTimeIsSet()) {
+    if (ntpServer) {
+      log_d("Got additional NTP Server %s.", ntpServer);
+      configTime(
+        0, 0, ntpServer,
+        "rustime01.rus.uni-stuttgart.de", "pool.ntp.org");
+    } else {
+      configTime(
+        0, 0,
+        "rustime01.rus.uni-stuttgart.de", "pool.ntp.org");
+    }
+  }
+  timeZone = TIMEZONE_UTC;
+}
+
+void TimeUtils::setClockByGps(uint32_t iTow, int32_t fTow, int16_t week, int8_t leapS) {
+  const time_t gpsTime = toTime(week, iTow / 1000);
+  if (timeZone == TIMEZONE_UTC && systemTimeIsSet()) {
+    log_i("Ignore new GPS time (%s), already set via NTP (%s).",
+          dateTimeToString(gpsTime).c_str(),
+          dateTimeToString().c_str());
+    return;
+  }
+  const int32_t gpsTimeUsec = ((iTow % 1000) * 1000) + (fTow / 1000);
+  const struct timeval now = {
+    .tv_sec = gpsTime,
+    .tv_usec = gpsTimeUsec
+  };
+  settimeofday(&now, nullptr);
+  timeZone = TIMEZONE_GPS;
+}
+
+void TimeUtils::setClockByNtpAndWait(const char* ntpServer) {
+  setClockByNtp(ntpServer);
+
+  log_i("Waiting for NTP time sync: ");
+  while (!systemTimeIsSet()) {
+    delay(500);
+    log_i(".");
+    yield();
+  }
+  timeZone = TIMEZONE_UTC;
+  log_i("NTP time set got %s.", dateTimeToString(time(nullptr)).c_str());
+}
+
+bool TimeUtils::systemTimeIsSet() {
+  time_t now = time(nullptr);
+  log_v("time %s.", dateTimeToString(now).c_str());
+  return now > 1609681614;
+}
+
+/* Determine the number of leap seconds to be considered at the given GPS
+ * time.
+ * TODO: Make this more fancy leverage AID_HUI info that can be stored on
+ *    SD or hardcode dates if announced at
+ *    https://www.ietf.org/timezones/data/leap-seconds.list
+ */
+int16_t TimeUtils::getLeapSecondsGps(time_t gps) {
+  return 18;
+}
+
+/* Determine the number of leap seconds to be considered at the given UTC
+ * time.
+ */
+int16_t TimeUtils::getLeapSecondsUtc(time_t utc) {
+  return 18;
+}
+
+time_t TimeUtils::gpsDayToTime(uint16_t week, uint16_t dayOfWeek) {
+  return (time_t) GPS_EPOCH_OFFSET + (SECONDS_PER_WEEK * week) + (SECONDS_PER_DAY * dayOfWeek);
+}
+
+time_t TimeUtils::toTime(uint16_t week, uint32_t weekTime) {
+  return (time_t) GPS_EPOCH_OFFSET + (SECONDS_PER_WEEK * week) + weekTime;
+}
+
+uint32_t TimeUtils::utcTimeToTimeOfWeek(time_t t) {
+  return (t - GPS_EPOCH_OFFSET - getLeapSecondsGps(t)) % SECONDS_PER_WEEK;
+}
+
+uint16_t TimeUtils::utcTimeToWeekNumber(time_t t) {
+  return (t - GPS_EPOCH_OFFSET - getLeapSecondsGps(t)) / SECONDS_PER_WEEK;
+}

--- a/src/utils/timeutils.h
+++ b/src/utils/timeutils.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019-2021 OpenBikeSensor Contributors
+ * Contact: https://openbikesensor.org
+ *
+ * This file is part of the OpenBikeSensor firmware.
+ *
+ * The OpenBikeSensor firmware is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * OpenBikeSensor firmware is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with the OpenBikeSensor firmware.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENBIKESENSORFIRMWARE_TIMEUTILS_H
+#define OPENBIKESENSORFIRMWARE_TIMEUTILS_H
+
+#include <Arduino.h>
+
+class TimeUtils {
+  public:
+    static const time_t PAST_TIME;
+    static String dateTimeToString(time_t timeIn = 0);
+    static String timeToString(time_t theTime =0);
+    static String dateTimeToHttpHeaderString(time_t theTime);
+    static void setClockByNtp(const char *ntpServer = nullptr);
+    static void setClockByNtpAndWait(const char *ntpServer = nullptr);
+    static void setClockByGps(uint32_t iTow, int32_t fTow, int16_t week, int8_t leapS = 0);
+    static bool systemTimeIsSet();
+    static int16_t getLeapSecondsGps(time_t gps);
+    static int16_t getLeapSecondsUtc(time_t gps);
+    static time_t gpsDayToTime(uint16_t week, uint16_t dayOfWeek);
+    static time_t toTime(uint16_t week, uint32_t weekTime);
+    static uint32_t utcTimeToTimeOfWeek(time_t t);
+    static uint16_t utcTimeToWeekNumber(time_t t);
+
+  private:
+    static const char *WEEK_DAYS[7];
+    static const char *MONTHS[12];
+    static const uint32_t GPS_EPOCH_OFFSET;
+    static const uint32_t SECONDS_PER_DAY;
+    static const uint32_t SECONDS_PER_WEEK;
+    static const char *weekDayToString(uint8_t wDay);
+    static const char *monthToString(uint8_t mon);
+};
+
+
+#endif //OPENBIKESENSORFIRMWARE_TIMEUTILS_H

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -162,6 +162,7 @@ bool CSVFileWriter::writeHeader(String trackId) {
   header += "MaximumValidFlightTimeMicroseconds=" + String(MAX_DURATION_MICRO_SEC) + "&";
   header += "BluetoothEnabled=" + String(config.bluetooth) + "&";
   header += "PresetId=default&";
+  header += "TimeZone=GPS&";
   header += "DistanceSensorsUsed=HC-SR04/JSN-SR04T\n";
 
   header += "Date;Time;Millis;Comment;Latitude;Longitude;Altitude;"

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -191,7 +191,7 @@ bool CSVFileWriter::append(DataSet &set) {
   }
 
   tm time;
-  localtime_r(&set.time, &time);
+  localtime_r(&(set.time), &time);
   char date[32];
   snprintf(date, sizeof(date),
     "%02d.%02d.%04d;%02d:%02d:%02d;%u;",

--- a/src/writer.h
+++ b/src/writer.h
@@ -37,7 +37,6 @@ struct DataSet {
   uint32_t  millis;
   String comment;
   GpsRecord gpsRecord;
-  float BatterieVoltage;
   double batteryLevel;
   std::vector<uint16_t> sensorValues;
   std::vector<uint16_t> confirmedDistances;


### PR DESCRIPTION
- remove GPS Fix option from all places
- recheck time set function followup to #242
- collect (GPS) statistic information when setting system time