### PR TITLE
Adapt to new api default url.

### DIFF
--- a/docs/software/firmware/obs_cfg.md
+++ b/docs/software/firmware/obs_cfg.md
@@ -54,7 +54,7 @@ relevant put the order of the array content.
           // Token used to authenticate and authorize at the portal.
             "portalToken": "thisIsAlsoSecret",
           // URL of the portal to be used
-            "portalUrl": "https://openbikesensor.hlrs.de",
+            "portalUrl": "https://portal.openbikesensor.org",
           // Array with privacy areas to be considered
             "privacyArea": [
                 {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -147,7 +147,7 @@ void ObsConfig::makeSureSystemDefaultsAreSet() {
   if (ensureSet(data, PROPERTY_WIFI_SSID, "")) {
     data[PROPERTY_WIFI_PASSWORD] = "";
   }
-  ensureSet(data, PROPERTY_PORTAL_URL, "https://openbikesensor.hlrs.de");
+  ensureSet(data, PROPERTY_PORTAL_URL, "https://portal.openbikesensor.org");
   ensureSet(data, PROPERTY_HTTP_PIN, ""); // we choose and save a new default when we need it
 
   const String &token = getProperty<const char*>(PROPERTY_PORTAL_TOKEN);


### PR DESCRIPTION
I just noticed that we still point to the old hlrs by default - Change to the new OBS portal as new default.