### PR TITLE
Improve display in server mode

### DIFF
--- a/src/OpenBikeSensorFirmware.cpp
+++ b/src/OpenBikeSensorFirmware.cpp
@@ -367,9 +367,9 @@ void serverLoop() {
 void handleButtonInServerMode() {
   button.handle();
   if (!configServerWasConnectedViaHttp()) {
-    displayTest->showTextOnGrid(0, 3, "Press the button for");
-    displayTest->showTextOnGrid(0, 4, "automatic track upload.");
     if (button.gotPressed()) {
+      displayTest->showTextOnGrid(0, 3, "Press the button for");
+      displayTest->showTextOnGrid(0, 4, "automatic track upload.");
       displayTest->clearProgressBar(5);
     } else if (button.getPreviousStateMillis() > 0 && button.getState() == HIGH) {
       const uint32_t buttonPressedMs = button.getCurrentStateMillis();

--- a/src/OpenBikeSensorFirmware.cpp
+++ b/src/OpenBikeSensorFirmware.cpp
@@ -367,10 +367,10 @@ void serverLoop() {
 void handleButtonInServerMode() {
   button.handle();
   if (!configServerWasConnectedViaHttp()) {
+    displayTest->showTextOnGrid(0, 3, "Press the button for");
+    displayTest->showTextOnGrid(0, 4, "automatic track upload.");
     if (button.gotPressed()) {
       displayTest->clearProgressBar(5);
-      displayTest->showTextOnGrid(0, 3, "Press the button for");
-      displayTest->showTextOnGrid(0, 4, "automatic track upload.");
     } else if (button.getPreviousStateMillis() > 0 && button.getState() == HIGH) {
       const uint32_t buttonPressedMs = button.getCurrentStateMillis();
       displayTest->drawProgressBar(5, buttonPressedMs, LONG_BUTTON_PRESS_TIME_MS);

--- a/src/configServer.cpp
+++ b/src/configServer.cpp
@@ -585,8 +585,6 @@ static void createHttpServer() {
   }
   serverSslCert = Https::getCertificate(progressTick);
   server = new HTTPSServer(serverSslCert, 443, 2);
-  displayTest->clear();
-  updateDisplay(displayTest);
   insecureServer = new HTTPServer(80, 2);
 
   beginPages();

--- a/src/displays.h
+++ b/src/displays.h
@@ -275,13 +275,15 @@ class SSD1306DisplayDevice : public DisplayDevice {
     }
 
     void clearProgressBar(uint8_t y) {
-      clearTextLine(y);
-      uint16_t rowOffset = y * 10 + 3;
-      m_display->setColor(BLACK);
-      m_display->fillRect(12, rowOffset, 104, 8);
-      m_display->setColor(WHITE);
-      m_display->display();
-      mLastProgress = UINT8_MAX;
+      if (UINT8_MAX != mLastProgress) {
+        clearTextLine(y);
+        uint16_t rowOffset = y * 10 + 3;
+        m_display->setColor(BLACK);
+        m_display->fillRect(12, rowOffset, 104, 8);
+        m_display->setColor(WHITE);
+        m_display->display();
+        mLastProgress = UINT8_MAX;
+      }
     }
 
     void clearTextLine(uint8_t y) {

--- a/src/utils/alpdata.cpp
+++ b/src/utils/alpdata.cpp
@@ -46,12 +46,13 @@ void AlpData::update(SSD1306DisplayDevice *display) {
     log_d("Next Update: %s",
           TimeUtils::dateTimeToString(lastWrite + 4 * 24 * 60 * 60).c_str());
     f.close();
+    display->showTextOnGrid(0, 5, "ALP not checked.");
     return;
   }
   f.close();
   log_d("Existing file last write %s", TimeUtils::dateTimeToString(f.getLastWrite()).c_str());
   log_d("Existing file is from %s", lastModified.c_str());
-  display->showTextOnGrid(0, 5, "ALP data ...");
+  display->showTextOnGrid(0, 5, "ALP data...");
 
   HTTPClient httpClient;
   httpClient.begin(ALP_DOWNLOAD_URL);
@@ -81,7 +82,7 @@ void AlpData::update(SSD1306DisplayDevice *display) {
       display->showTextOnGrid(0, 5, "ALP data updated!");
     }
   } else if (httpCode == 304) { // Not-Modified
-    display->showTextOnGrid(0,5, "ALP data up to date.");
+    display->showTextOnGrid(0, 5, "ALP data was up to date.");
     log_i("All fine, not modified!");
   } else if (httpCode > 0) {
     display->showTextOnGrid(0,4, String("ALP data failed ") + String(httpCode).c_str());


### PR DESCRIPTION
Fixes #284    
* Show the press button info after APL data handled, not just when the button got pressed
* Do not clear the display, when the HTTPSServer ist created. Thus, the APL info stays in the display until the loading bar shows up