### PR TITLE
Change byte order of base MAC in the SoftAP SSID.

### DIFF
--- a/src/configServer.cpp
+++ b/src/configServer.cpp
@@ -39,6 +39,7 @@
 #include "utils/https.h"
 #include "utils/timeutils.h"
 #include "obsimprov.h"
+#include <esp_system.h>
 
 using namespace httpsserver;
 
@@ -764,13 +765,14 @@ static void createImprovServer() {
 void startServer(ObsConfig *obsConfig) {
   theObsConfig = obsConfig;
 
-  const uint64_t chipid_num = ESP.getEfuseMac();
-  String esp_chipid = String((uint16_t)(chipid_num >> 32), HEX);
-  esp_chipid += String((uint32_t)chipid_num, HEX);
-  esp_chipid.toUpperCase();
-  OBS_ID = "OpenBikeSensor-" + esp_chipid;
-  OBS_ID_SHORT = "OBS-" + String((uint16_t)(ESP.getEfuseMac() >> 32), HEX);
-  OBS_ID_SHORT.toUpperCase();
+  uint8_t mac[6];
+  esp_efuse_mac_get_default(mac);
+
+  char ssid[28];
+  snprintf(esp_chipid, sizeof(esp_chipid), "OpenBikeSensor-%02X%02X%02X%02X%02X%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);  
+
+  OBS_ID = String(ssid);
+  OBS_ID_SHORT = "OBS-" + OBS_ID.substring(15,19);
 
   displayTest->clear();
   displayTest->showTextOnGrid(0, 0, "Ver.:");


### PR DESCRIPTION
With this PR the computed SSID for the ConfigServer access point contains the hexadecimal digits in the same order as they are reported for the base MAC.

**reported MAC**
```
$ esptool.py --chip esp32 read_mac
esptool.py v3.0
Serial port /dev/ttyUSB0
Connecting........_____..
Chip is ESP32-D0WDQ6 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:11:ae:8b:32:ac
```

**SSID of the access point**
```
$ nmcli --fields BSSID,SSID,CHAN device wifi
BSSID              SSID                         CHAN 
4C:11:AE:8B:32:AD  OpenBikeSensor-4C11AE8B32AC  1    
```

The MAC of the SoftAP (BSSID) is different to the base MAC id. An explanation can be found at
https://espressif-docs.readthedocs-hosted.com/projects/esp-idf/en/stable/api-reference/system/system.html#mac-address

This fixes #315.