### PR TITLE
Set bootloader flash parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,10 +134,10 @@ jobs:
         mv 0x01000.bin 0x01000.bin.org
         ${ESPTOOL} --trace  --chip esp32 merge_bin --output 0x01000.bin  \
             --flash_freq keep --flash_mode dio --flash_size 4MB \
-            --target-offset 0x01000
+            --target-offset 0x01000 \
             0x01000 0x01000.bin.org
-        ${ESPTOOL} --chip esp32 image_info --version 2 0x01000.bin.org
-        ${ESPTOOL} --chip esp32 image_info --version 2 0x01000.bin
+        ${ESPTOOL} --chip esp32 image_info --version 2 0x01000.bin.org || echo image_info failed
+        ${ESPTOOL} --chip esp32 image_info --version 2 0x01000.bin || echo image_info failed
         
         cp src/fonts/LICENSE.txt LICENSE-OpenSans.txt
         wget --no-verbose -O COPYRIGHT-ESP.html https://docs.espressif.com/projects/esp-idf/en/latest/esp32/COPYRIGHT.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,18 @@ jobs:
         cp /github/home/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x0e000.bin
         cp bin/.pio/build/esp32dev/firmware.bin 0x10000.bin
         cp bin/.pio/build/esp32dev/firmware.bin firmware.bin
+        esptool.py --trace  --chip esp32 merge_bin --output merged.bin  \
+            --flash_freq 80m --flash_mode dio --flash_size 4MB \
+            0x01000 0x01000.bin \
+            0x08000 0x08000.bin \
+            0x0e000 0x0e000.bin \
+            0x10000 0x10000.bin
+        esptool.py --chip esp32 image_info --version 2 merged.bin
         cp src/fonts/LICENSE.txt LICENSE-OpenSans.txt
         wget --no-verbose -O COPYRIGHT-ESP.html https://docs.espressif.com/projects/esp-idf/en/latest/esp32/COPYRIGHT.html
         wget --no-verbose -O LICENSE-ARDUINO-ESP32.md https://github.com/espressif/arduino-esp32/raw/master/LICENSE.md
         zip --junk-paths obs-${{ env.OBS_VERSION }}-initial-flash.zip \
+          merged.bin \
           0x*.bin \
           COPYRIGHT-ESP.html \
           LICENSE-ARDUINO-ESP32.md \
@@ -173,6 +181,7 @@ jobs:
       with:
         name: obs-${{ env.OBS_VERSION }}-initial-flash
         path: |
+          merged.bin
           0x*.bin
           COPYRIGHT-ESP.html
           LICENSE-ARDUINO-ESP32.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,15 +114,23 @@ jobs:
         cp /github/home/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x0e000.bin
         cp bin/.pio/build/esp32dev/firmware.bin 0x10000.bin
         cp bin/.pio/build/esp32dev/firmware.bin firmware.bin
-        find bin/ -name "esptool.py" \
-        find /github/home/.platformio/ -name "esptool.py" \
+        find bin/ -name "esptool.py"
+        find /github/home/.platformio/ -name "esptool.py"
         esptool.py --trace  --chip esp32 merge_bin --output merged.bin  \
-            --flash_freq 80m --flash_mode dio --flash_size 4MB \
+            --flash_freq keep --flash_mode dio --flash_size 4MB \
             0x01000 0x01000.bin \
             0x08000 0x08000.bin \
             0x0e000 0x0e000.bin \
             0x10000 0x10000.bin
         esptool.py --chip esp32 image_info --version 2 merged.bin
+        mv 0x01000.bin 0x01000.bin.org
+        esptool.py --trace  --chip esp32 merge_bin --output 0x01000.bin  \
+            --flash_freq keep --flash_mode dio --flash_size 4MB \
+            --target-offset 0x01000
+            0x01000 0x01000.bin.org
+        esptool.py --chip esp32 image_info --version 2 0x01000.bin.org
+        esptool.py --chip esp32 image_info --version 2 0x01000.bin
+        
         cp src/fonts/LICENSE.txt LICENSE-OpenSans.txt
         wget --no-verbose -O COPYRIGHT-ESP.html https://docs.espressif.com/projects/esp-idf/en/latest/esp32/COPYRIGHT.html
         wget --no-verbose -O LICENSE-ARDUINO-ESP32.md https://github.com/espressif/arduino-esp32/raw/master/LICENSE.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
         ls -l /github/home/.platformio/packages/tool-esptoolpy/esptool.py 
         ls -l /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py
         id 
+        chmod +x /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py
+        chmod +x /github/home/.platformio/packages/tool-esptoolpy/esptool.py
         echo /github/home/.platformio/packages/tool-esptoolpy/esptool.py 
         /github/home/.platformio/packages/tool-esptoolpy/esptool.py version
         echo /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,13 +125,12 @@ jobs:
         /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py version
         ESPTOOL=/github/home/.platformio/packages/tool-esptoolpy/esptool.py
         ${ESPTOOL} version
-        ${ESPTOOL} --trace  --chip esp32 merge_bin --output merged.bin  \
+        ${ESPTOOL} --trace --chip esp32 merge_bin --output merged.bin  \
             --flash_freq keep --flash_mode dio --flash_size 4MB \
             0x01000 0x01000.bin \
             0x08000 0x08000.bin \
             0x0e000 0x0e000.bin \
             0x10000 0x10000.bin
-        ${ESPTOOL} --chip esp32 image_info --version 2 merged.bin
         mv 0x01000.bin 0x01000.bin.org
         ${ESPTOOL} --trace  --chip esp32 merge_bin --output 0x01000.bin  \
             --flash_freq keep --flash_mode dio --flash_size 4MB \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,36 +114,28 @@ jobs:
         cp /github/home/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x0e000.bin
         cp bin/.pio/build/esp32dev/firmware.bin 0x10000.bin
         cp bin/.pio/build/esp32dev/firmware.bin firmware.bin
-        ls -l /github/home/.platformio/packages/tool-esptoolpy/esptool.py 
-        ls -l /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py
-        id 
-        chmod +x /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py
-        chmod +x /github/home/.platformio/packages/tool-esptoolpy/esptool.py
-        echo /github/home/.platformio/packages/tool-esptoolpy/esptool.py 
-        /github/home/.platformio/packages/tool-esptoolpy/esptool.py version
-        echo /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py 
-        /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py version
         ESPTOOL=/github/home/.platformio/packages/tool-esptoolpy/esptool.py
-        ${ESPTOOL} version
-        ${ESPTOOL} --trace --chip esp32 merge_bin --output merged.bin  \
-            --flash_freq keep --flash_mode dio --flash_size 4MB \
-            0x01000 0x01000.bin \
-            0x08000 0x08000.bin \
-            0x0e000 0x0e000.bin \
-            0x10000 0x10000.bin
+        chmod +x ${ESPTOOL}
+        # CMD to create a merged binary (still missing flash.app)
+        # ${ESPTOOL} --trace --chip esp32 merge_bin --output merged.bin  \
+        #    --flash_freq keep --flash_mode dio --flash_size 4MB \
+        #    0x01000 0x01000.bin \
+        #    0x08000 0x08000.bin \
+        #    0x0e000 0x0e000.bin \
+        #    0x10000 0x10000.bin
+        echo Original bootloader params
+        ${ESPTOOL} --chip esp32 image_info --version 2 0x01000.bin || echo image_info for original bootloader failed
         mv 0x01000.bin 0x01000.bin.org
         ${ESPTOOL} --trace  --chip esp32 merge_bin --output 0x01000.bin  \
             --flash_freq keep --flash_mode dio --flash_size 4MB \
             --target-offset 0x01000 \
             0x01000 0x01000.bin.org
-        ${ESPTOOL} --chip esp32 image_info --version 2 0x01000.bin.org || echo image_info failed
+        echo OpenBikeSensor bootloader params
         ${ESPTOOL} --chip esp32 image_info --version 2 0x01000.bin || echo image_info failed
-        
         cp src/fonts/LICENSE.txt LICENSE-OpenSans.txt
         wget --no-verbose -O COPYRIGHT-ESP.html https://docs.espressif.com/projects/esp-idf/en/latest/esp32/COPYRIGHT.html
         wget --no-verbose -O LICENSE-ARDUINO-ESP32.md https://github.com/espressif/arduino-esp32/raw/master/LICENSE.md
         zip --junk-paths obs-${{ env.OBS_VERSION }}-initial-flash.zip \
-          merged.bin \
           0x*.bin \
           COPYRIGHT-ESP.html \
           LICENSE-ARDUINO-ESP32.md \
@@ -199,7 +191,6 @@ jobs:
       with:
         name: obs-${{ env.OBS_VERSION }}-initial-flash
         path: |
-          merged.bin
           0x*.bin
           COPYRIGHT-ESP.html
           LICENSE-ARDUINO-ESP32.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,22 +114,26 @@ jobs:
         cp /github/home/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x0e000.bin
         cp bin/.pio/build/esp32dev/firmware.bin 0x10000.bin
         cp bin/.pio/build/esp32dev/firmware.bin firmware.bin
-        find bin/ -name "esptool.py"
-        find /github/home/.platformio/ -name "esptool.py"
-        esptool.py --trace  --chip esp32 merge_bin --output merged.bin  \
+        echo /github/home/.platformio/packages/tool-esptoolpy/esptool.py 
+        /github/home/.platformio/packages/tool-esptoolpy/esptool.py version
+        echo /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py 
+        /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py version
+        ESPTOOL=/github/home/.platformio/packages/tool-esptoolpy/esptool.py
+        ${ESPTOOL} version
+        ${ESPTOOL} --trace  --chip esp32 merge_bin --output merged.bin  \
             --flash_freq keep --flash_mode dio --flash_size 4MB \
             0x01000 0x01000.bin \
             0x08000 0x08000.bin \
             0x0e000 0x0e000.bin \
             0x10000 0x10000.bin
-        esptool.py --chip esp32 image_info --version 2 merged.bin
+        ${ESPTOOL} --chip esp32 image_info --version 2 merged.bin
         mv 0x01000.bin 0x01000.bin.org
-        esptool.py --trace  --chip esp32 merge_bin --output 0x01000.bin  \
+        ${ESPTOOL} --trace  --chip esp32 merge_bin --output 0x01000.bin  \
             --flash_freq keep --flash_mode dio --flash_size 4MB \
             --target-offset 0x01000
             0x01000 0x01000.bin.org
-        esptool.py --chip esp32 image_info --version 2 0x01000.bin.org
-        esptool.py --chip esp32 image_info --version 2 0x01000.bin
+        ${ESPTOOL} --chip esp32 image_info --version 2 0x01000.bin.org
+        ${ESPTOOL} --chip esp32 image_info --version 2 0x01000.bin
         
         cp src/fonts/LICENSE.txt LICENSE-OpenSans.txt
         wget --no-verbose -O COPYRIGHT-ESP.html https://docs.espressif.com/projects/esp-idf/en/latest/esp32/COPYRIGHT.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,9 @@ jobs:
         cp /github/home/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x0e000.bin
         cp bin/.pio/build/esp32dev/firmware.bin 0x10000.bin
         cp bin/.pio/build/esp32dev/firmware.bin firmware.bin
+        ls -l /github/home/.platformio/packages/tool-esptoolpy/esptool.py 
+        ls -l /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py
+        id 
         echo /github/home/.platformio/packages/tool-esptoolpy/esptool.py 
         /github/home/.platformio/packages/tool-esptoolpy/esptool.py version
         echo /github/home/.platformio/packages/framework-arduinoespressif32/tools/esptool.py 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
         cp /github/home/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x0e000.bin
         cp bin/.pio/build/esp32dev/firmware.bin 0x10000.bin
         cp bin/.pio/build/esp32dev/firmware.bin firmware.bin
+        find bin/ -name "esptool.py" \
+        find /github/home/.platformio/ -name "esptool.py" \
         esptool.py --trace  --chip esp32 merge_bin --output merged.bin  \
             --flash_freq 80m --flash_mode dio --flash_size 4MB \
             0x01000 0x01000.bin \

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ src_dir = src
 extra_configs = custom_config.ini
 
 [env:esp32dev]
-platform = espressif32 @ ^5.1
+platform = espressif32 @ ^5.2
 board = esp32dev
 framework = arduino
 monitor_speed = 115200


### PR DESCRIPTION
After ESP IDF and Arduino updates the provided bootloaders come without proper flash parameters for our ESP32. So we have to create a own bootloader with our parameters. This is done by using the `esptool.py`during the build.