### PR TITLE
Fix wrong stored values with negative latitude or longitude

### DIFF
--- a/src/gpsrecord.cpp
+++ b/src/gpsrecord.cpp
@@ -115,7 +115,7 @@ String GpsRecord::toScaledString(const int32_t value, const uint16_t scale) {
   }
   char buffer[32];
   const int32_t scl = pow10[scale];
-  snprintf(buffer, sizeof(buffer), "%d.%0*d", value / scl, scale, value % scl );
+  snprintf(buffer, sizeof(buffer), "%d.%0*d", value / scl, scale, abs(value % scl) );
   return String(buffer);
 }
 


### PR DESCRIPTION
When the latitude or longitude is negative, the value recorded is in the format -x.-xxxxxxx