### PR TITLE
Flush CSV and SD buffer when privacy zone is entered

### DIFF
--- a/src/OpenBikeSensorFirmware.cpp
+++ b/src/OpenBikeSensorFirmware.cpp
@@ -541,8 +541,12 @@ void loop() {
     delete dataset;
   }
 
-  if (transmitConfirmedData) {
-    // After confirmation make sure it will be written to SD card directly
+  // After confirmation make sure it will be written to SD card directly
+  if (transmitConfirmedData ||
+    // also write if we are inside a privacy area ...
+    (currentSet->isInsidePrivacyArea
+    // ... and privacy mode does not require to write all sets
+      && (config.privacyConfig & AbsolutePrivacy) || (config.privacyConfig & OverridePrivacy))) {
     // so no confirmed sets might be lost
     if (writer) {
       writer->flush();

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -101,9 +101,10 @@ bool FileWriter::appendString(const String &s) {
 
 bool FileWriter::flush() {
   bool result;
-#ifdef DEVELOP
-  Serial.printf("Writing to concrete file.\n");
-#endif
+  if (mBuffer.isEmpty()) {
+    return true;
+  }
+  log_v("Writing to concrete file.");
   const auto start = millis();
   result = FileUtil::appendFile(SD, mFileName.c_str(), mBuffer.c_str() );
   mBuffer.clear();
@@ -111,9 +112,7 @@ bool FileWriter::flush() {
   if (!mFinalFileName) {
     correctFilename();
   }
-#ifdef DEVELOP
-  Serial.printf("Writing to concrete file done took %lums.\n", mWriteTimeMillis);
-#endif
+  log_v("Writing to concrete file done took %lums.", mWriteTimeMillis);
   return result;
 }
 

--- a/src/writer.h
+++ b/src/writer.h
@@ -44,7 +44,7 @@ struct DataSet {
   uint16_t confirmed = 0;
   String marked;
   bool invalidMeasurement = false;
-  bool isInsidePrivacyArea;
+  bool isInsidePrivacyArea = false;
   uint8_t factor = MICRO_SEC_TO_CM_DIVIDER;
   uint8_t measurements;
 


### PR DESCRIPTION
- if privacy setting does prevent new records being created flush when entering any privacy zone. This will reduce the number of lost records at the end of a trip and reduces the risk of write operations during power of.
- leaves a small gap if the OBS frequently enters and leaves the privacy zone. This is expected to happen only in rare cases and for a short periode. Open a new issue if you observe this.
- fixes #334 