### PR TITLE
Refresh build tool dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         echo $VERSION > version.txt
         echo Building OBS Version: $VERSION
         sed -i 's|-DBUILD_NUMBER=\\"-dev\\"|-DBUILD_NUMBER=\\"'${SEPARATOR}${PATCH}'\\"|' platformio.ini
-        echo "SONAR_SCANNER_VERSION=4.7.0.2747" >> $GITHUB_ENV
+        echo "SONAR_SCANNER_VERSION=4.8.0.2856" >> $GITHUB_ENV
 
     - name: Cache SonarCloud packages
       id: cache-sonar
@@ -72,8 +72,8 @@ jobs:
         path: |
           ~/.sonar/cache
           sonarqube
-        key: ${{ runner.os }}-sonar-${{ env.SONAR_SCANNER_VERSION }}-ng5
-        restore-keys: ${{ runner.os }}-sonar-${{ env.SONAR_SCANNER_VERSION }}-ng5
+        key: ${{ runner.os }}-sonar-${{ env.SONAR_SCANNER_VERSION }}-ng6
+        restore-keys: ${{ runner.os }}-sonar-${{ env.SONAR_SCANNER_VERSION }}-ng6
 
     - name: Install SonarQube dependencies
       if: steps.cache-sonar.outputs.cache-hit != 'true'
@@ -167,6 +167,8 @@ jobs:
         sed -i 's|\.pio/|bin/.pio/|g' \
             sonarqube-out/build-wrapper-dump.json
         # replace gcc with our script that reports the fake arch "le32-unknown-nacl"
+        ## might be fixed with https://sonarsource.atlassian.net/browse/CPP-4482
+        ## not as of 2023-06-09
         sed -i "s|/github/home/.platformio/packages/toolchain-xtensa-esp32/bin/xtensa-esp32-elf-g..|`pwd`/.github/fake-cc|g" \
             sonarqube-out/build-wrapper-dump.json
         ./sonarqube/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin/sonar-scanner \
@@ -176,8 +178,6 @@ jobs:
           -Dsonar.coverage.exclusions=**/* \
           -Dsonar.sources=src \
           -Dsonar.sourceEncoding=UTF-8 \
-          -Dsonar.cfamily.cache.enabled=false \
-          -Dsonar.cfamily.threads=1 \
           -Dsonar.cfamily.build-wrapper-output=sonarqube-out \
           -Dsonar.projectVersion=${{ env.OBS_MAJOR_VERSION }}
 


### PR DESCRIPTION
- use current sonar scanner
- drop fake gcc, might be fixed upstream via https://sonarsource.atlassian.net/browse/CPP-4482