### PR TITLE
Take care of libraries

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -56,8 +56,8 @@ lib_deps =
     adafruit/Adafruit BMP280 Library@^2.6.8
     pololu/VL53L0X@^1.3.1
     ; https://github.com/fhessel/esp32_https_server
-    https://github.com/amandel/esp32_https_server.git#hotfix/openbikesensor
-    ; TODO: https://github.com/jasenk2/esp32_https_server.git#esp_tls
+    ; https://github.com/amandel/esp32_https_server.git#hotfix/openbikesensor
+    https://github.com/jasenk2/esp32_https_server.git#esp_tls
     ; esp32_https_server@
 build_flags =
     -DCORE_DEBUG_LEVEL=3

--- a/src/OpenBikeSensorFirmware.h
+++ b/src/OpenBikeSensorFirmware.h
@@ -26,7 +26,7 @@
 
 #include <Arduino.h>
 #define CIRCULAR_BUFFER_INT_SAFE
-#include <CircularBuffer.h>
+#include <CircularBuffer.hpp>
 
 #include "config.h"
 #include "configServer.h"


### PR DESCRIPTION
- Avoid compile time warnings from CircularBuffer like…
```
In file included from src/OpenBikeSensorFirmware.h:29,
                 from src/configServer.cpp:30:
.pio/libdeps/esp32dev/CircularBuffer/CircularBuffer.h:3:102: note: #pragma message: WARNING: please change import directive from CircularBiffer.h to CircularBuffer.hpp
 #pragma message("WARNING: please change import directive from CircularBiffer.h to CircularBuffer.hpp")

```
- https://github.com/fhessel/esp32_https_server seems to be unmaintained since a while and throws deprecation warnings by the used TLS library openssl. https://github.com/jasenk2/esp32_https_server/tree/esp_tls at least addresses this deprecation.

A build containing those changes was tested for three weeks "on the bike". Testing included track uploads & OBS Webinterface access.