### PR TITLE
Fixes #369 wait for gps

### DIFF
--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -1288,7 +1288,6 @@ void Gps::handleUbxNavTimeGps(const GpsBuffer::UbxNavTimeGps &message, const uin
     mIncomingGpsRecord.setWeek(mLastGpsWeek);
   }
   if ((message.valid & 0x03) == 0x03  // WEEK && TOW
-      && delayMs < 20
       && message.tAcc < (20 * 1000 * 1000 /* 20ms */)
       && (mLastTimeTimeSet == 0
           || (mLastTimeTimeSet + (2 * 60 * 1000 /* 2 minutes */)) < receivedMs)) {

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -739,6 +739,8 @@ bool Gps::hasFix(DisplayDevice *display) const {
     log_d("Got location...");
     display->showTextOnGrid(2, 4, "Got location");
     result = true;
+  } else {
+    log_d("NO location...mLastTimeTimeSet=%u", mLastTimeTimeSet);
   }
   return result;
 }

--- a/src/gpsrecord.cpp
+++ b/src/gpsrecord.cpp
@@ -116,6 +116,7 @@ String GpsRecord::toScaledString(const int32_t value, const uint16_t scale) {
 }
 
 bool GpsRecord::hasValidFix() const {
+  log_d("hasValidFix: mFixStatus=%u, mHdop=%u, mSatellitesUsed=%u", mFixStatus, mHdop, mSatellitesUsed);
   return (mFixStatus == FIX_2D || mFixStatus == FIX_3D || mFixStatus == GPS_AND_DEAD_RECKONING)
     && mHdop != 9999 && mSatellitesUsed != 0;
 }


### PR DESCRIPTION
As I can see delayMs is the delay between the handling of the first byte of a GPS-Message block and the last Byte of the UbxNavTime Msg.

We have configured the GPS to get a block each second. (Sol, Pollsh, Dop, Velned and TimeGps)

I don't think the order of the single messages is specified and maydiffer.

This delay is no indicator of the quality of the GPS measurement but the performance of the OBS firmware.

Removing this conditions seems to fix #369
