### PR TITLE
Changes to the GPS logic for newer GPS.

### DIFF
--- a/src/OpenBikeSensorFirmware.cpp
+++ b/src/OpenBikeSensorFirmware.cpp
@@ -399,9 +399,10 @@ void setup() {
       esp_bt_mem_release(ESP_BT_MODE_BTDM)); // no bluetooth at all here.
 
     delay(200);
-    startServer(&cfg);
+    obsDisplay->showTextOnGrid(2, obsDisplay->newLine(), "Start GPS...");
     gps.begin();
     gps.setStatisticsIntervalInSeconds(2); // ??
+    startServer(&cfg);
     while (true) {
       yield();
       serverLoop();

--- a/src/OpenBikeSensorFirmware.cpp
+++ b/src/OpenBikeSensorFirmware.cpp
@@ -446,7 +446,6 @@ void setup() {
   gps.handle();
 
   setupBluetooth(cfg, trackUniqueIdentifier);
-  obsDisplay->clear();
   obsDisplay->showTextOnGrid(2, obsDisplay->newLine(), "Wait for GPS");
   obsDisplay->newLine();
   gps.handle();

--- a/src/OpenBikeSensorFirmware.cpp
+++ b/src/OpenBikeSensorFirmware.cpp
@@ -446,7 +446,7 @@ void setup() {
   gps.handle();
 
   setupBluetooth(cfg, trackUniqueIdentifier);
-
+  obsDisplay->clear();
   obsDisplay->showTextOnGrid(2, obsDisplay->newLine(), "Wait for GPS");
   obsDisplay->newLine();
   gps.handle();

--- a/src/configServer.cpp
+++ b/src/configServer.cpp
@@ -729,7 +729,7 @@ static void wifiConnectedActions() {
   if (WiFiClass::status() == WL_CONNECTED) {
     TimeUtils::setClockByNtpAndWait(WiFi.gatewayIP().toString().c_str());
   }
-  if (SD.begin() && WiFiClass::status() == WL_CONNECTED) {
+  if (SD.begin() && WiFiClass::status() == WL_CONNECTED && gps.is_neo6()) {
     AlpData::update(obsDisplay);
   }
 

--- a/src/configServer.cpp
+++ b/src/configServer.cpp
@@ -729,7 +729,8 @@ static void wifiConnectedActions() {
   if (WiFiClass::status() == WL_CONNECTED) {
     TimeUtils::setClockByNtpAndWait(WiFi.gatewayIP().toString().c_str());
   }
-  if (SD.begin() && WiFiClass::status() == WL_CONNECTED && gps.is_neo6()) {
+  if (SD.begin() && WiFiClass::status() == WL_CONNECTED 
+       && (!gps.moduleIsAlive() || gps.is_neo6())) {
     AlpData::update(obsDisplay);
   }
 

--- a/src/configServer.cpp
+++ b/src/configServer.cpp
@@ -1134,7 +1134,7 @@ static void handleColdStartGPS(HTTPRequest *, HTTPResponse * res) {
   String html = createPage(gpsColdIndex);
   html = replaceDefault(html, "Navigation");
   sendHtml(res, html);
-  gps.coldResetGps();
+  gps.coldStartGps();
   res->finalize();
 }
 

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -862,11 +862,11 @@ void Gps::showWaitStatus(DisplayDevice const * display) const {
     obsDisplay->showTextOnGrid(2, display->currentLine() - 1, satellitesString[0]);
     obsDisplay->showTextOnGrid(2, display->currentLine(), satellitesString[1]);
     if (!is_neo6()){
-      obsDisplay->showTextOnGrid(0, 1, satellitesString[2]);
-      obsDisplay->showTextOnGrid(0, 2, String(mCurrentGpsRecord.mLatitude));
-      obsDisplay->showTextOnGrid(0, 3, String(mCurrentGpsRecord.mLongitude));
-      obsDisplay->showTextOnGrid(0, 4, String(hw())+" Detail");
-
+      obsDisplay->showTextOnGrid(0, 1, String(hw())+" Detail");
+      obsDisplay->showTextOnGrid(0, 2, satellitesString[2]);
+      obsDisplay->showTextOnGrid(0, 3, String(mCurrentGpsRecord.mLatitude));
+      obsDisplay->showTextOnGrid(0, 4, String(mCurrentGpsRecord.mLongitude));
+      obsDisplay->showTextOnGrid(0, 5, "Gain:" + String(mLastGain) + " Jam:" + String(mLastJamInd));
     }
 }
 

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -848,7 +848,7 @@ void Gps::showWaitStatus(DisplayDevice const * display) const {
      obsDisplay->clear();
      clear = true;
   }
-  String satellitesString[3];
+  String satellitesString[2];
   if (mValidMessagesReceived == 0) { // could not get any valid char from GPS module
     satellitesString[0] = "OFF?";
   } else if (mLastTimeTimeSet == 0) {
@@ -858,17 +858,21 @@ void Gps::showWaitStatus(DisplayDevice const * display) const {
     satellitesString[0] = String(hw()).substring(1) + TimeUtils::timeToString();
     satellitesString[1] = String(mCurrentGpsRecord.mSatellitesUsed) + "sats SN:" + String(mLastNoiseLevel);
   }
-  satellitesString[2] = String(mCurrentGpsRecord.mFixStatus) + "<fx m>" + String(mValidMessagesReceived);
+  obsDisplay->showTextOnGrid(2, display->currentLine() - 1, satellitesString[0]);
+  obsDisplay->showTextOnGrid(2, display->currentLine(), satellitesString[1]);
+  if (!is_neo6()){
+    obsDisplay->showTextOnGrid(0, 1, String(hw())+" GPS");
+    obsDisplay->showTextOnGrid(2, 1, "HDOP: " + getHdopAsString() + "D");
 
-    obsDisplay->showTextOnGrid(2, display->currentLine() - 1, satellitesString[0]);
-    obsDisplay->showTextOnGrid(2, display->currentLine(), satellitesString[1]);
-    if (!is_neo6()){
-      obsDisplay->showTextOnGrid(0, 1, String(hw())+" Detail");
-      obsDisplay->showTextOnGrid(0, 2, "Gain:" + String(mLastGain) + " Jam:" + String(mLastJamInd));
-      obsDisplay->showTextOnGrid(0, 3, satellitesString[2]);
-      obsDisplay->showTextOnGrid(0, 4, String(mCurrentGpsRecord.mLatitude));
-      obsDisplay->showTextOnGrid(0, 5, String(mCurrentGpsRecord.mLongitude));
-    }
+    obsDisplay->showTextOnGrid(0, 2, "Jam: " + String(mLastJamInd));
+    obsDisplay->showTextOnGrid(2, 2, "Msgs: " + String(mValidMessagesReceived));
+    obsDisplay->showTextOnGrid(2, 3, "Fix: " + String(mCurrentGpsRecord.mFixStatus) + "D");
+    obsDisplay->showTextOnGrid(0, 3, "lat,lon:");
+
+
+    obsDisplay->showTextOnGrid(0, 4, String(mCurrentGpsRecord.mLatitude));
+    obsDisplay->showTextOnGrid(0, 5, String(mCurrentGpsRecord.mLongitude));
+  }
 }
 
 bool Gps::moduleIsAlive() const {

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -359,6 +359,11 @@ void Gps::coldStartGps() {
   handle();
   //const uint8_t UBX_CFG_RST[] = {0x00, 0x00, 0x02, 0x00}; // WARM START
   const uint8_t UBX_CFG_RST[] = {0xFF, 0x81, 0x04, 0x00}; // Cold START '0xFF, 0x81, 0x04, 0x00'
+  // https://content.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_UBX-13003221.pdf?utm_content=UBX-13003221
+  //          eph=1, alm=1, health=1, klob=1, pos=1, clkd=1, osc=1, utc=1, rtc=1, aop=1, resetMode=4, reserved0=0
+  // can be generated via pyubx2 UBXMessage reset = pyubx2.UBXMessage(...)
+  // output via ", ".join([f"0x{b:02X}" for b in reset.payload])
+
   // we had the case where the reset took several seconds
   // see https://github.com/openbikesensor/OpenBikeSensorFirmware/issues/309
   // Newer firmware (like M10 and likely also M8) will not ack this
@@ -863,10 +868,10 @@ void Gps::showWaitStatus(DisplayDevice const * display) const {
     obsDisplay->showTextOnGrid(2, display->currentLine(), satellitesString[1]);
     if (!is_neo6()){
       obsDisplay->showTextOnGrid(0, 1, String(hw())+" Detail");
-      obsDisplay->showTextOnGrid(0, 2, satellitesString[2]);
-      obsDisplay->showTextOnGrid(0, 3, String(mCurrentGpsRecord.mLatitude));
-      obsDisplay->showTextOnGrid(0, 4, String(mCurrentGpsRecord.mLongitude));
-      obsDisplay->showTextOnGrid(0, 5, "Gain:" + String(mLastGain) + " Jam:" + String(mLastJamInd));
+      obsDisplay->showTextOnGrid(0, 2, "Gain:" + String(mLastGain) + " Jam:" + String(mLastJamInd));
+      obsDisplay->showTextOnGrid(0, 3, satellitesString[2]);
+      obsDisplay->showTextOnGrid(0, 4, String(mCurrentGpsRecord.mLatitude));
+      obsDisplay->showTextOnGrid(0, 5, String(mCurrentGpsRecord.mLongitude));
     }
 }
 

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -342,7 +342,6 @@ void Gps::softResetGps() {
   log_i("Soft-RESET GPS!");
   handle();
   const uint8_t UBX_CFG_RST[] = {0x00, 0x00, 0x02, 0x00}; // WARM START
-  //const uint8_t UBX_CFG_RST[] = {0xFF, 0x81, 0x04, 0x00}; // Cold START '0xFF, 0x81, 0x04, 0x00'
   // we had the case where the reset took several seconds
   // see https://github.com/openbikesensor/OpenBikeSensorFirmware/issues/309
   // Newer firmware (like M10 and likely also M8) will not ack this
@@ -356,13 +355,7 @@ void Gps::softResetGps() {
 void Gps::coldStartGps() {
   log_i("Cold-Start GPS!");
   handle();
-  //const uint8_t UBX_CFG_RST[] = {0x00, 0x00, 0x02, 0x00}; // WARM START
-  const uint8_t UBX_CFG_RST[] = {0xFF, 0x81, 0x04, 0x00}; // Cold START '0xFF, 0x81, 0x04, 0x00'
-  // https://content.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_UBX-13003221.pdf?utm_content=UBX-13003221
-  //          eph=1, alm=1, health=1, klob=1, pos=1, clkd=1, osc=1, utc=1, rtc=1, aop=1, resetMode=4, reserved0=0
-  // can be generated via pyubx2 UBXMessage reset = pyubx2.UBXMessage(...)
-  // output via ", ".join([f"0x{b:02X}" for b in reset.payload])
-
+  const uint8_t UBX_CFG_RST[] = {0xFF, 0xFF, 0x00, 0x00}; 
   // we had the case where the reset took several seconds
   // see https://github.com/openbikesensor/OpenBikeSensorFirmware/issues/309
   // Newer firmware (like M10 and likely also M8) will not ack this

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -361,7 +361,7 @@ void Gps::coldStartGps() {
   // Newer firmware (like M10 and likely also M8) will not ack this
   // message so we do not wait for the ACK
   sendUbx(UBX_MSG::CFG_RST, UBX_CFG_RST, 4);
-  waitForData(1000);
+  waitForData(3000);
   handle();
   log_i("Cold Start GPS! Done");
 }

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -1181,18 +1181,33 @@ void Gps::parseUbxMessage() {
       break;
     case (uint16_t) UBX_MSG::MON_HW: {
       const char* aStatus;
-      switch (mGpsBuffer.monHw.aStatus) {
-        case mGpsBuffer.monHw.INIT: aStatus = "init"; break;
-        case mGpsBuffer.monHw.DONTKNOW: aStatus = "?"; break;
-        case mGpsBuffer.monHw.OK: aStatus = "ok"; break;
-        case mGpsBuffer.monHw.SHORT: aStatus = "short"; break;
-        case mGpsBuffer.monHw.OPEN: aStatus = "open"; break;
-        default: aStatus = "invalid";
+      if (is_neo6()) {
+        switch (mGpsBuffer.monHw.aStatus) {
+          case mGpsBuffer.monHw.INIT: aStatus = "init"; break;
+          case mGpsBuffer.monHw.DONTKNOW: aStatus = "?"; break;
+          case mGpsBuffer.monHw.OK: aStatus = "ok"; break;
+          case mGpsBuffer.monHw.SHORT: aStatus = "short"; break;
+          case mGpsBuffer.monHw.OPEN: aStatus = "open"; break;
+          default: aStatus = "invalid";
+        }
+        log_d("MON-HW Antenna Status %d %s, Antenna Power %d, Gain (0-8191) %d, noise level %d", mGpsBuffer.monHw.aStatus, aStatus, mGpsBuffer.monHw.aPower, mGpsBuffer.monHw.agcCnt, mGpsBuffer.monHw.noisePerMs);
+        mLastNoiseLevel = mGpsBuffer.monHw.noisePerMs;
+        mLastGain = mGpsBuffer.monHw.agcCnt;
+        mLastJamInd = mGpsBuffer.monHw.jamInd;
+      } else {
+        switch (mGpsBuffer.monHwNew.aStatus) {
+          case mGpsBuffer.monHwNew.INIT: aStatus = "init"; break;
+          case mGpsBuffer.monHwNew.DONTKNOW: aStatus = "?"; break;
+          case mGpsBuffer.monHwNew.OK: aStatus = "ok"; break;
+          case mGpsBuffer.monHwNew.SHORT: aStatus = "short"; break;
+          case mGpsBuffer.monHwNew.OPEN: aStatus = "open"; break;
+          default: aStatus = "invalid";
+        }
+        log_d("MON-HW Antenna Status %d %s, Antenna Power %d, Gain (0-8191) %d, noise level %d", mGpsBuffer.monHwNew.aStatus, aStatus, mGpsBuffer.monHwNew.aPower, mGpsBuffer.monHwNew.agcCnt, mGpsBuffer.monHwNew.noisePerMs);
+        mLastNoiseLevel = mGpsBuffer.monHwNew.noisePerMs;
+        mLastGain = mGpsBuffer.monHwNew.agcCnt;
+        mLastJamInd = mGpsBuffer.monHwNew.jamInd;
       }
-      log_d("MON-HW Antenna Status %d %s, Antenna Power %d, Gain (0-8191) %d, noise level %d", mGpsBuffer.monHw.aStatus, aStatus, mGpsBuffer.monHw.aPower, mGpsBuffer.monHw.agcCnt, mGpsBuffer.monHw.noisePerMs);
-      mLastNoiseLevel = mGpsBuffer.monHw.noisePerMs;
-      mLastGain = mGpsBuffer.monHw.agcCnt;
-      mLastJamInd = mGpsBuffer.monHw.jamInd;
     }
       break;
     case (uint16_t) UBX_MSG::NAV_STATUS: {

--- a/src/gps.h
+++ b/src/gps.h
@@ -111,7 +111,8 @@ class Gps {
     uint32_t getNumberOfAlpBytesSent() const;
     uint32_t getUnexpectedCharReceivedCount() const;
 
-    void coldResetGps();
+    void coldStartGps();
+
 
   private:
     /* ALP msgs up to 0x16A seen might be more? */
@@ -640,7 +641,6 @@ class Gps {
     void prepareGpsData(uint32_t tow, uint32_t messageStartedMillisTicks);
 
     void softResetGps();
-    void coldStartGps();
 
     void handleUbxNavTimeGps(const GpsBuffer::UbxNavTimeGps & message, const uint32_t receivedMs, const uint32_t delayMs);
     void handleUbxAidIni(const GpsBuffer::AidIni &message) const;

--- a/src/gps.h
+++ b/src/gps.h
@@ -320,6 +320,36 @@ class Gps {
         uint32_t pinIrq;
         uint32_t pullH;
         uint32_t pullL;
+      } monHwNew;
+      struct __attribute__((__packed__)) {
+        UBX_HEADER ubxHeader;
+        uint32_t pinSel;
+        uint32_t pinBank;
+        uint32_t pinDir;
+        uint32_t pinVal;
+        uint16_t noisePerMs;
+        uint16_t agcCnt; // AGC (Automatic Gain Control) Monitor, as percentage of maximum gain,range 0 to 8191 (100%)
+        enum ANT_STATUS : uint8_t {
+          INIT = 0,
+          DONTKNOW = 1,
+          OK = 2,
+          SHORT = 3,
+          OPEN = 4,
+        } aStatus;
+        enum ANT_POWER : uint8_t {
+          OFF = 0,
+          ON = 1,
+          POWER_DONTKNOW = 2,
+        } aPower;
+        uint8_t flags;
+        uint8_t reserved1;
+        uint32_t usedMask;
+        uint8_t vp[25];
+        uint8_t jamInd;
+        uint16_t reserved3;
+        uint32_t pinIrq;
+        uint32_t pullH;
+        uint32_t pullL;
       } monHw;
       struct __attribute__((__packed__)) {
         UBX_HEADER ubxHeader;

--- a/src/gps.h
+++ b/src/gps.h
@@ -567,11 +567,17 @@ class Gps {
     bool mGpsNeedsConfigUpdate = false;
     static const String INF_SEVERITY_STRING[];
 
+    char hwString[10];
+
     void configureGpsModule();
 
     bool encode(uint8_t data);
 
     bool setBaud();
+    bool is_neo6() const;
+    bool is_neo8() const;
+    bool is_neo10() const;
+    String hw() const;
 
     bool checkCommunication();
 
@@ -625,6 +631,7 @@ class Gps {
     void prepareGpsData(uint32_t tow, uint32_t messageStartedMillisTicks);
 
     void softResetGps();
+    void coldStartGps();
 
     void handleUbxNavTimeGps(const GpsBuffer::UbxNavTimeGps & message, const uint32_t receivedMs, const uint32_t delayMs);
     void handleUbxAidIni(const GpsBuffer::AidIni &message) const;

--- a/src/gps.h
+++ b/src/gps.h
@@ -113,6 +113,9 @@ class Gps {
 
     void coldStartGps();
 
+    bool is_neo6() const;
+    bool is_neo8() const;
+    bool is_neo10() const;
 
   private:
     /* ALP msgs up to 0x16A seen might be more? */
@@ -584,9 +587,7 @@ class Gps {
     bool encode(uint8_t data);
 
     bool setBaud();
-    bool is_neo6() const;
-    bool is_neo8() const;
-    bool is_neo10() const;
+
     String hw() const;
 
     bool checkCommunication();

--- a/src/gpsrecord.cpp
+++ b/src/gpsrecord.cpp
@@ -40,6 +40,8 @@ void GpsRecord::reset(uint32_t tow, uint32_t gpsWeek, uint32_t createdAtMillisTi
   mVelocitySet = false;
   mInfoSet = false;
   mHdopSet = false;
+  hwVer = "unknown";
+  swVer = "unknown";
 }
 
 void GpsRecord::setWeek(uint32_t week) {

--- a/src/gpsrecord.cpp
+++ b/src/gpsrecord.cpp
@@ -40,8 +40,6 @@ void GpsRecord::reset(uint32_t tow, uint32_t gpsWeek, uint32_t createdAtMillisTi
   mVelocitySet = false;
   mInfoSet = false;
   mHdopSet = false;
-  hwVer = "unknown";
-  swVer = "unknown";
 }
 
 void GpsRecord::setWeek(uint32_t week) {

--- a/src/gpsrecord.h
+++ b/src/gpsrecord.h
@@ -102,8 +102,6 @@ class GpsRecord {
     uint32_t mCreatedAtMillisTicks;
     static const int32_t pow10[10];
     static String toScaledString(int32_t value, uint16_t scale);
-    String hwVer;
-    String swVer;
 };
 
 

--- a/src/gpsrecord.h
+++ b/src/gpsrecord.h
@@ -102,7 +102,8 @@ class GpsRecord {
     uint32_t mCreatedAtMillisTicks;
     static const int32_t pow10[10];
     static String toScaledString(int32_t value, uint16_t scale);
-
+    String hwVer;
+    String swVer;
 };
 
 

--- a/src/utils/alpdata.cpp
+++ b/src/utils/alpdata.cpp
@@ -172,6 +172,7 @@ size_t AlpData::loadMessage(uint8_t *data, size_t size) {
     result = f.read(data, size);
     f.close();
     log_d("Read %d bytes", result);
+    SD.remove(AID_INI_DATA_FILE_NAME);
   }
   return result;
 }


### PR DESCRIPTION
This adds a few changes to the GPS logic
- on non-neo6m we coldstart on bootup
- there is an extra http endpoint to trigger a coldstart (by @Jens-Kassel)
- we only do aid_ini and aid_alp on neo6m
- we interpret MON_HW in the way it is sent on neo8m (which only differs in bytes that we weren't using on neo6m)  (by @Jens-Kassel)
- We store gain and jamming indicator for display and logging (by @Jens-Kassel)
- We display more information from MON-HW 
- we give more debug data on-screen for non-neo6m
- Instead of ignoring datetimes below a minimum precision we keep asking for the datetime messge in short intervals until we receive one with a high precision (based on @Jens-Kassel s findings from last november).

@amandel what do you think?